### PR TITLE
refactor: drive nav from site.header_pages

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,13 +6,12 @@
 
     <div class="header-right">
       <nav class="site-nav">
-        <a href="{{ '/about/' | relative_url }}">About</a>
-        <a href="{{ '/team/' | relative_url }}">Team</a>
-        <a href="{{ '/publications/' | relative_url }}">Publications</a>
-        <a href="{{ '/software/' | relative_url }}">Software</a>
-        <a href="{{ '/projects/' | relative_url }}">Projects</a>
-        <a href="{{ '/contact/' | relative_url }}">Contact</a>
-        <a href="{{ '/joinus/' | relative_url }}" class="btn-outline">Join Us</a>
+        {% for page_path in site.header_pages %}
+          {% assign nav_page = site.pages | where: "path", page_path | first %}
+          {% if nav_page %}
+            <a href="{{ nav_page.url | relative_url }}"{% if nav_page.nav_class %} class="{{ nav_page.nav_class }}"{% endif %}>{{ nav_page.title }}</a>
+          {% endif %}
+        {% endfor %}
       </nav>
 
       <button class="nav-hamburger" aria-label="Toggle menu" onclick="document.querySelector('.mobile-nav').classList.toggle('open');this.classList.toggle('active')">
@@ -45,13 +44,12 @@
   <button class="mobile-nav-close" aria-label="Close menu">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
   </button>
-  <a href="{{ '/about/' | relative_url }}">About</a>
-  <a href="{{ '/team/' | relative_url }}">Team</a>
-  <a href="{{ '/publications/' | relative_url }}">Publications</a>
-  <a href="{{ '/software/' | relative_url }}">Software</a>
-  <a href="{{ '/projects/' | relative_url }}">Projects</a>
-  <a href="{{ '/contact/' | relative_url }}">Contact</a>
-  <a href="{{ '/joinus/' | relative_url }}" class="btn-outline">Join Us</a>
+  {% for page_path in site.header_pages %}
+    {% assign nav_page = site.pages | where: "path", page_path | first %}
+    {% if nav_page %}
+      <a href="{{ nav_page.url | relative_url }}"{% if nav_page.nav_class %} class="{{ nav_page.nav_class }}"{% endif %}>{{ nav_page.title }}</a>
+    {% endif %}
+  {% endfor %}
 </nav>
 
 <script>

--- a/joinus.md
+++ b/joinus.md
@@ -2,6 +2,7 @@
 layout: page
 title: Join Us
 permalink: /joinus/
+nav_class: btn-outline
 ---
 
 <div class="recruitment-section korean">


### PR DESCRIPTION
Nav links are now data-driven. Adding a new page to the nav only requires one line in _config.yml — no template edits ever again.