### PR TITLE
fix: mobile perf — apply CSS fixes to actual stylesheet

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -1250,6 +1250,8 @@ html[data-theme="dark"] #leaflet-map .leaflet-control-zoom a {
   .stats-grid {
     grid-template-columns: 1fr;
     border-radius: 16px;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
   .stat-item {
     border-right: none;
@@ -1267,9 +1269,25 @@ html[data-theme="dark"] #leaflet-map .leaflet-control-zoom a {
   .footer-right {
     text-align: left;
   }
+  .site-header.scrolled {
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
   .aurora-glow {
-    width: 400px;
-    height: 400px;
+    display: none;
+  }
+  body {
+    background-image: none;
+  }
+  .global-vignette,
+  .hud-frame {
+    display: none;
+  }
+  #webgl-canvas {
+    filter: none;
+  }
+  .global-scanlines {
+    display: none;
   }
   .info-section {
     min-height: auto;
@@ -1283,12 +1301,6 @@ html[data-theme="dark"] #leaflet-map .leaflet-control-zoom a {
     min-height: auto;
     padding-top: 4rem;
     padding-bottom: 4rem;
-  }
-  .global-scanlines {
-    display: none;
-  }
-  .global-vignette {
-    opacity: 0.45;
   }
   /* Inner pages mobile */
   .post,


### PR DESCRIPTION
## Summary
- Previous mobile CSS optimizations were in orphaned `_sass/theme.scss` — never reached the browser
- Moved all fixes into `assets/main.css` (the real stylesheet): remove aurora blur, vignette, HUD, body grid, canvas filter, backdrop-filter on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)