### PR TITLE
fix: research area wipe when editing multiple members

### DIFF
--- a/workspace/admin.js
+++ b/workspace/admin.js
@@ -181,7 +181,7 @@ export function initTagInput(container, initialValues = []) {
 
   render();
   return {
-    getValues: () => values,
+    getValues: () => [...values],
     setValues: (v) => { values.splice(0, values.length, ...v); render(); }
   };
 }


### PR DESCRIPTION
## Summary
- `initTagInput.getValues()` returned a direct reference to the internal array
- Editing member 2 mutated member 1's research_area via shared reference
- Fix: return `[...values]` (shallow copy) so each save gets an independent array

🤖 Generated with [Claude Code](https://claude.com/claude-code)