### PR TITLE
fix: publish button stuck on Publishing after success

### DIFF
--- a/workspace/editors/config.js
+++ b/workspace/editors/config.js
@@ -111,6 +111,7 @@ async function publishConfig() {
     await githubUpdateFile('_config.yml', updatedYaml, 'admin: update site config');
     configRaw = updatedYaml;
     EDITABLE_FIELDS.forEach(f => { originalValues[f.key] = getYamlValue(configRaw, f.key); });
+    btn.textContent = origText;
     clearDirty();
     toast('Config published! Full site rebuild in ~2-3 min.', 'success');
   } catch (err) {

--- a/workspace/editors/lablife.js
+++ b/workspace/editors/lablife.js
@@ -203,6 +203,7 @@ async function publishLabLife() {
   btn.disabled = true; btn.textContent = t('publishing');
   try {
     await githubUpdateFile('_data/lablife.json', JSON.stringify(lablifeData, null, 2), 'admin: update lab life gallery');
+    btn.innerHTML = origHTML;
     clearDirty();
     toast('Lab Life published! Site will rebuild in ~1-2 min.', 'success');
   } catch (err) {

--- a/workspace/editors/projects.js
+++ b/workspace/editors/projects.js
@@ -210,6 +210,7 @@ async function publishProjects() {
   btn.disabled = true; btn.textContent = t('publishing');
   try {
     await githubUpdateFile('_data/projects.json', JSON.stringify(projectsData, null, 2), 'admin: update projects data');
+    btn.innerHTML = origHTML;
     clearDirty();
     toast('Projects published! Site will rebuild in ~1-2 min.', 'success');
   } catch (err) {

--- a/workspace/editors/team.js
+++ b/workspace/editors/team.js
@@ -248,6 +248,7 @@ async function publishTeam() {
   btn.disabled = true; btn.textContent = t('publishing');
   try {
     await githubUpdateFile('_data/team.json', JSON.stringify(teamData, null, 2), 'admin: update team data');
+    btn.innerHTML = origHTML;
     clearDirty();
     toast('Team published! Site will rebuild in ~1-2 min.', 'success');
   } catch (err) {


### PR DESCRIPTION
## Summary
- Restore publish button text/icon after successful publish in all 4 editors (team, projects, lablife, config)
- Previously only the error path restored the button — success left it stuck as "Publishing..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)