### PR TITLE
refactor: research area — plain text input instead of tags

### DIFF
--- a/workspace/editors/team.js
+++ b/workspace/editors/team.js
@@ -1,9 +1,8 @@
-import { githubGetFile, githubUpdateFile, githubUploadImage, decodeGithubContent, toast, openModal, closeModal, initTagInput, confirm, t, applyI18n } from '../admin.js';
+import { githubGetFile, githubUpdateFile, githubUploadImage, decodeGithubContent, toast, openModal, closeModal, confirm, t, applyI18n } from '../admin.js';
 
 let teamData = null;
 let editingMember = null;
 let editingAlumni = null;
-let tagsController = null;
 let isDirty = false;
 
 function markDirty() {
@@ -185,14 +184,10 @@ function openMemberModal(si, member) {
   const preview = document.getElementById('member-img-preview');
   if (member?.image) { preview.src = BASE + '/images/' + member.image; preview.style.display = 'block'; }
   else { preview.style.display = 'none'; }
-  const researchArr = Array.isArray(member?.research_area)
-    ? member.research_area
-    : member?.research_area ? [member.research_area] : [];
-  if (!tagsController) {
-    tagsController = initTagInput(document.getElementById('member-research-tags'), researchArr);
-  } else {
-    tagsController.setValues(researchArr);
-  }
+  const research = Array.isArray(member?.research_area)
+    ? member.research_area.join(', ')
+    : member?.research_area || '';
+  document.getElementById('member-research-area').value = research;
   openModal('member-modal');
 }
 
@@ -205,7 +200,7 @@ function saveMember() {
     link: document.getElementById('member-link').value.trim() || undefined,
     bio: document.getElementById('member-bio').value.trim() || undefined,
     image: document.getElementById('member-image').value.trim() || undefined,
-    research_area: tagsController?.getValues() || [],
+    research_area: document.getElementById('member-research-area').value.trim() || undefined,
   };
   Object.keys(m).forEach(k => m[k] === undefined && delete m[k]);
   if (mi === -1) teamData.sections[si].members.push(m);

--- a/workspace/index.html
+++ b/workspace/index.html
@@ -32,7 +32,7 @@ permalink: /workspace/
         <div class="field"><label data-i18n="f_profile_link">Profile Link</label><input type="url" id="member-link" placeholder="https://scholar.google.com/…"></div>
       </div>
       <div class="field"><label data-i18n="f_bio">Bio</label><textarea id="member-bio" placeholder="Short biography…"></textarea></div>
-      <div class="field"><label data-i18n="f_research">Research Areas</label><div class="tags-input" id="member-research-tags"></div><div class="field-hint" data-i18n="tag_hint">Type and press Enter to add</div></div>
+      <div class="field"><label data-i18n="f_research">Research Areas</label><input type="text" id="member-research-area" placeholder="e.g. LiDAR Panoptic Segmentation, Semi-supervised Learning."></div>
     </div>
     <div class="modal-footer">
       <button class="btn btn-ghost" id="member-modal-cancel" data-i18n="btn_cancel">Cancel</button>


### PR DESCRIPTION
## Summary
- Replace tag input with simple text field for research_area (it's a string in team.json, not an array)
- Eliminates the shared-reference bug that wiped research areas on multi-edit
- Removed unused `initTagInput` import and `tagsController` variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)