### PR TITLE
fix: correct Google Maps link on contact page

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -8,7 +8,7 @@ permalink: /contact/
   <div class="contact-hero-map">
     <div id="leaflet-map"></div>
     <div class="map-nav-buttons">
-      <a href="https://www.google.com/maps/place/숭실대학교+형남공학관/@37.4957479,126.9561148,17z" target="_blank" class="map-nav-btn">
+      <a href="https://maps.app.goo.gl/DUrdeyab2ryxP1VN6" target="_blank" class="map-nav-btn">
         <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z" fill="#EA4335"/>
           <circle cx="12" cy="9" r="2.8" fill="#fff"/>


### PR DESCRIPTION
## Summary
- Update Google Maps button to use correct shortened link

🤖 Generated with [Claude Code](https://claude.com/claude-code)