### PR TITLE
feat: year nav sidebar on publications page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,7 @@
     // Fade out on navigate
     document.addEventListener('click', function(e){
       var a = e.target.closest('a');
-      if(!a || !a.href || a.target === '_blank' || a.href.startsWith('#') || a.host !== location.host) return;
+      if(!a || !a.href || a.target === '_blank' || (a.getAttribute('href')||'').startsWith('#') || a.host !== location.host) return;
       e.preventDefault();
       var overlay = document.querySelector('.page-transition');
       overlay.classList.remove('done');

--- a/assets/main.css
+++ b/assets/main.css
@@ -679,16 +679,7 @@ p {
   margin-bottom: 2rem;
 }
 
-.post a:not(.link-arrow) {
-  color: var(--text-primary);
-  border-bottom: 1px solid var(--border-color);
-  padding-bottom: 2px;
-  transition: border-color 0.3s;
-}
 
-.post a:not(.link-arrow):hover {
-  border-color: var(--text-primary);
-}
 
 .post table {
   width: 100%;
@@ -911,7 +902,50 @@ p {
 .pub-scholar-link:hover { background: var(--light-background); border-color: var(--border-color); }
 .pub-scholar-link svg { width: 12px; height: 12px; stroke: currentColor; stroke-width: 1.5; fill: none; }
 .pub-updated { font-size: 0.8rem; color: var(--light-text); margin-bottom: 3rem; }
-.publication-section { margin-bottom: 3rem; }
+/* Year navigation sidebar */
+.year-nav {
+  position: fixed;
+  right: clamp(6px, 1.5vw, 20px);
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+  padding: 0.4rem 0.25rem;
+  background: var(--bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+  max-height: 80vh;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+.year-nav::-webkit-scrollbar { display: none; }
+.year-nav-item {
+  display: block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  font-family: 'Space Mono', monospace;
+  color: var(--light-text);
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  cursor: pointer;
+  white-space: nowrap;
+  line-height: 1.5;
+}
+.year-nav-item:hover {
+  background: var(--surface-color);
+  color: var(--text-primary);
+}
+.year-nav-item.active {
+  background: var(--text-primary);
+  color: var(--bg-color);
+}
+.publication-section { margin-bottom: 3rem; scroll-margin-top: 100px; }
 .publication-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.5rem; }
 .publication-item {
   padding: 0.8rem 1.2rem;
@@ -1310,6 +1344,22 @@ html[data-theme="dark"] #leaflet-map .leaflet-control-zoom a {
   .post h1,
   .post-title {
     font-size: 1.8rem;
+  }
+  .year-nav {
+    right: 2px;
+    padding: 0.25rem 0.1rem;
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--bg-color) 85%, transparent);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
+  .year-nav-item {
+    font-size: 0.55rem;
+    padding: 0.05rem 0.25rem;
+    line-height: 1.4;
+  }
+  .publication-section {
+    padding-right: 2rem;
   }
   .publications-summary {
     gap: 1.5rem;

--- a/publications.md
+++ b/publications.md
@@ -25,8 +25,14 @@ permalink: /publications/
 
 <p class="pub-updated">Last synced: {{ site.data.publications.last_updated }}</p>
 
+<nav class="year-nav" id="year-nav" aria-label="Jump to year">
+  {% for year_group in site.data.publications.publications %}
+  <a href="#year-{{ year_group.year }}" class="year-nav-item" data-year="{{ year_group.year }}">{{ year_group.year }}</a>
+  {% endfor %}
+</nav>
+
 {% for year_group in site.data.publications.publications %}
-<section class="publication-section">
+<section class="publication-section" id="year-{{ year_group.year }}">
   <h2 class="publication-year">{{ year_group.year }}</h2>
   <ul class="publication-list">
     {% for pub in year_group.entries %}
@@ -46,3 +52,43 @@ permalink: /publications/
 <div class="pub-tooltip" id="pubTooltip"></div>
 
 <script src="{{ '/assets/js/pub-tooltip.js' | relative_url }}"></script>
+<script>
+(function() {
+  var nav = document.getElementById('year-nav');
+  if (!nav) return;
+  var items = nav.querySelectorAll('.year-nav-item');
+  var sections = document.querySelectorAll('.publication-section');
+
+  // Smooth scroll on click
+  items.forEach(function(item) {
+    item.addEventListener('click', function(e) {
+      e.preventDefault();
+      var target = document.querySelector(item.getAttribute('href'));
+      if (target) target.scrollIntoView({ behavior: 'smooth' });
+    });
+  });
+
+  // Scroll spy — highlight active year
+  var ticking = false;
+  function updateActive() {
+    var scrollY = window.scrollY + 160;
+    var current = null;
+    sections.forEach(function(sec) {
+      if (sec.offsetTop <= scrollY) current = sec.id;
+    });
+    items.forEach(function(item) {
+      var isActive = item.getAttribute('href') === '#' + current;
+      item.classList.toggle('active', isActive);
+      if (isActive) {
+        item.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      }
+    });
+    ticking = false;
+  }
+
+  window.addEventListener('scroll', function() {
+    if (!ticking) { ticking = true; requestAnimationFrame(updateActive); }
+  });
+  updateActive();
+})();
+</script>


### PR DESCRIPTION
## Summary
- Fixed vertical year sidebar (1997–2026) on right edge of publications page
- Scroll-spy highlights current year, click to jump
- Fix page-blank bug: hash links were intercepted by page transition overlay
- Remove `.post a:not(.link-arrow)` color override
- Mobile: compact semi-transparent nav with content padding to avoid overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)