### PR TITLE
chore: re-sync publications with Scholar order

### DIFF
--- a/_data/publications.json
+++ b/_data/publications.json
@@ -2,7 +2,7 @@
   "last_updated": "2026-03-16",
   "scholar_id": "TARMZOsAAAAJ",
   "scholar_url": "https://scholar.google.com/citations?user=TARMZOsAAAAJ&hl=en",
-  "total_publications": 251,
+  "total_publications": 261,
   "total_citations": 8753,
   "h_index": 34,
   "i10_index": 71,
@@ -24,33 +24,6 @@
     {
       "year": 2025,
       "entries": [
-        {
-          "title": "Interruption-Aware Computation Offloading in the Industrial Internet of Things",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:86PQX7AUzd4C",
-          "citation": "KA Bui, M Yoo - Sensors 25 (9), 2904, 2025, 2025",
-          "cited_by": 4,
-          "venue": "Sensors 25 (9), 2904",
-          "authors": "KA Bui, M Yoo",
-          "description": "Designing an efficient task offloading system is essential in the Industrial Internet of Things (IIoT). Owing to the limited computational capability of IIoT devices, offloading tasks to edge servers enhances computational efficiency. When an edge server is overloaded, it may experience interruptions, preventing it from serving local devices. Existing studies mainly address interruptions by rerouting, rescheduling, or implementing reactive strategies to mitigate their impact. In this study, we introduce an interruption-aware proactive task offloading framework for IIoT. We develop a load-based interruption model in which the probability of server interruption is formulated as an exponential function of the total computational load, which provides a more realistic estimation of service availability. This framework employs Multi-Agent Advantage Actor–Critic (MAA2C)—a simple yet efficient approach that enables decentralized decision-making while handling large action spaces and maintaining coordination through the centralized critic to make adaptive offloading decisions, taking into account edge availability, resource limitations, device cooperation, and interruptions. Experimental results show that our approach effectively reduces the average total service delay by optimizing the tradeoff between system delay and availability in IIoT networks. Additionally, we investigate the impact of various system parameters on performance under an interruptible edge task offloading scenario, providing valuable insights into how these parameters influence the overall system behavior and efficiency."
-        },
-        {
-          "title": "Depth completion method and apparatus using a spatial-temporal",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:LI9QrySNdTsC",
-          "citation": "MS YOO, MT Nguyen - US Patent 12,322,127, 2025, 2025",
-          "cited_by": 2,
-          "venue": "US Patent 12,322,127",
-          "authors": "MS YOO, MT Nguyen",
-          "description": "Provided are a depth completion method and apparatus using spatial-temporal information. The depth completion apparatus according to the present invention comprises a processor; and a memory connected to the processor, wherein the memory stores program instructions executable by the processor for performing operations comprising receiving an RGB image and a sparse image through a camera and LiDAR, generating a dense first depth map by processing color information of the RGB image through a first branch based on an encoder-decoder, generating a dense second depth map by up-sampling the sparse image through a second branch based on an encoder-decoder, generating a third depth map by fusing the first depth map and the second depth map, and generating a final depth map including a trajectory of a moving object included in an RGB image continuously captured during movement by …"
-        },
-        {
-          "title": "Quality of Experience Optimization for AR Service in an MEC Federation System",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:PVjk1bu6vJQC",
-          "citation": "HM Do, TP Tran, M Yoo - IEEE Access, 2025, 2025",
-          "cited_by": 1,
-          "venue": "IEEE Access",
-          "authors": "HM Do, TP Tran, M Yoo",
-          "description": "Augmented reality (AR) in the internet of things requires ultra-low latency, high-resolution video, and fairness in multi-user environments, which pose challenges for traditional cloud and edge computing. To address this shortcoming, we studied AR subtask offloading and resource allocation in a multi-hop, multi-access edge computing federation. Our approach improves the quality of experience (QoE) by optimizing video quality and reducing delay while ensuring fairness, which is modeled as the ratio between provided and required quality. Instead of sequential execution, we adopt parallel AR subtask dependency processing to minimize latency. We propose an improved deep deterministic policy gradient algorithm for efficient solution exploration. Additionally, we implement strict training process monitoring to optimize resource usage and ensure sustainability. Experiments demonstrate that our method improves …"
-        },
         {
           "title": "SSUFormer: Spatial-spectral SSUFormer for improving hyperspectral image classification",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:kh2fBNsKQNwC",
@@ -86,6 +59,33 @@
           "venue": "US Patent 12,405,834",
           "authors": "MS Yoo",
           "description": "Disclosed is an integrated clustering system including a master node that sets environment setting for clustering and generate an access token by installing a management program, a plurality of worker nodes that set environment setting based on an environment variable including an IP address of the master node and the access token and perform clustering with the master node by installing the management program, and a system control unit that extracts runtimes of clustering groups including the master node and the plurality of worker nodes which are clustered, and compares the runtime of one of the clustering groups with the runtimes of other clustering group than the one clustering group."
+        },
+        {
+          "title": "Depth completion method and apparatus using a spatial-temporal",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:LI9QrySNdTsC",
+          "citation": "MS YOO, MT Nguyen - US Patent 12,322,127, 2025, 2025",
+          "cited_by": 2,
+          "venue": "US Patent 12,322,127",
+          "authors": "MS YOO, MT Nguyen",
+          "description": "Provided are a depth completion method and apparatus using spatial-temporal information. The depth completion apparatus according to the present invention comprises a processor; and a memory connected to the processor, wherein the memory stores program instructions executable by the processor for performing operations comprising receiving an RGB image and a sparse image through a camera and LiDAR, generating a dense first depth map by processing color information of the RGB image through a first branch based on an encoder-decoder, generating a dense second depth map by up-sampling the sparse image through a second branch based on an encoder-decoder, generating a third depth map by fusing the first depth map and the second depth map, and generating a final depth map including a trajectory of a moving object included in an RGB image continuously captured during movement by …"
+        },
+        {
+          "title": "Interruption-Aware Computation Offloading in the Industrial Internet of Things",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:86PQX7AUzd4C",
+          "citation": "KA Bui, M Yoo - Sensors 25 (9), 2904, 2025, 2025",
+          "cited_by": 4,
+          "venue": "Sensors 25 (9), 2904",
+          "authors": "KA Bui, M Yoo",
+          "description": "Designing an efficient task offloading system is essential in the Industrial Internet of Things (IIoT). Owing to the limited computational capability of IIoT devices, offloading tasks to edge servers enhances computational efficiency. When an edge server is overloaded, it may experience interruptions, preventing it from serving local devices. Existing studies mainly address interruptions by rerouting, rescheduling, or implementing reactive strategies to mitigate their impact. In this study, we introduce an interruption-aware proactive task offloading framework for IIoT. We develop a load-based interruption model in which the probability of server interruption is formulated as an exponential function of the total computational load, which provides a more realistic estimation of service availability. This framework employs Multi-Agent Advantage Actor–Critic (MAA2C)—a simple yet efficient approach that enables decentralized decision-making while handling large action spaces and maintaining coordination through the centralized critic to make adaptive offloading decisions, taking into account edge availability, resource limitations, device cooperation, and interruptions. Experimental results show that our approach effectively reduces the average total service delay by optimizing the tradeoff between system delay and availability in IIoT networks. Additionally, we investigate the impact of various system parameters on performance under an interruptible edge task offloading scenario, providing valuable insights into how these parameters influence the overall system behavior and efficiency."
+        },
+        {
+          "title": "Quality of Experience Optimization for AR Service in an MEC Federation System",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:PVjk1bu6vJQC",
+          "citation": "HM Do, TP Tran, M Yoo - IEEE Access, 2025, 2025",
+          "cited_by": 1,
+          "venue": "IEEE Access",
+          "authors": "HM Do, TP Tran, M Yoo",
+          "description": "Augmented reality (AR) in the internet of things requires ultra-low latency, high-resolution video, and fairness in multi-user environments, which pose challenges for traditional cloud and edge computing. To address this shortcoming, we studied AR subtask offloading and resource allocation in a multi-hop, multi-access edge computing federation. Our approach improves the quality of experience (QoE) by optimizing video quality and reducing delay while ensuring fairness, which is modeled as the ratio between provided and required quality. Instead of sequential execution, we adopt parallel AR subtask dependency processing to minimize latency. We propose an improved deep deterministic policy gradient algorithm for efficient solution exploration. Additionally, we implement strict training process monitoring to optimize resource usage and ensure sustainability. Experiments demonstrate that our method improves …"
         }
       ]
     },
@@ -93,40 +93,22 @@
       "year": 2024,
       "entries": [
         {
-          "title": "Enhancing intrusion detection in wireless sensor networks using a GSWO-CatBoost approach",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:q3CdL3IzO_QC",
-          "citation": "TM Nguyen, HHP Vo, M Yoo - Sensors 24 (11), 3339, 2024, 2024",
-          "cited_by": 44,
-          "venue": "Sensors 24 (11), 3339",
-          "authors": "TM Nguyen, HHP Vo, M Yoo",
-          "description": "Intrusion detection systems (IDSs) in wireless sensor networks (WSNs) rely heavily on effective feature selection (FS) for enhanced efficacy. This study proposes a novel approach called Genetic Sacrificial Whale Optimization (GSWO) to address the limitations of conventional methods. GSWO combines a genetic algorithm (GA) and whale optimization algorithms (WOA) modified by applying a new three-population division strategy with a proposed conditional inherited choice (CIC) to overcome premature convergence in WOA. The proposed approach achieves a balance between exploration and exploitation and enhances global search abilities. Additionally, the CatBoost model is employed for classification, effectively handling categorical data with complex patterns. A new technique for fine-tuning CatBoost’s hyperparameters is introduced, using effective quantization and the GSWO strategy. Extensive experimentation on various datasets demonstrates the superiority of GSWO-CatBoost, achieving higher accuracy rates on the WSN-DS, WSNBFSF, NSL-KDD, and CICIDS2017 datasets than the existing approaches. The comprehensive evaluations highlight the real-time applicability and accuracy of the proposed method across diverse data sources, including specialized WSN datasets and established benchmarks. Specifically, our GSWO-CatBoost method has an inference time nearly 100 times faster than deep learning methods while achieving high accuracy rates of 99.65%, 99.99%, 99.76%, and 99.74% for WSN-DS, WSNBFSF, NSL-KDD, and CICIDS2017, respectively."
+          "title": "LiDAR Panoptic Segmentation With Learnable Embeddings and Dynamic Decoder",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:hCrLmN-GePgC",
+          "citation": "NL Nguyen, M Yoo - IEEE Sensors Journal 25 (1), 2019-2029, 2024, 2024",
+          "cited_by": 0,
+          "venue": "IEEE Sensors Journal 25 (1), 2019-2029",
+          "authors": "NL Nguyen, M Yoo",
+          "description": "Light detection and ranging (LiDAR) panoptic segmentation is a crucial task for autonomous driving, enabling comprehensive scene understanding by unifying semantic and instance segmentation. However, existing methods face challenges in effectively utilizing available information when constructing positional embeddings (PEs) and adapting to varying scene complexities. This article presents a novel approach to addressing these limitations. We introduce two key innovations: 1) an improved PE technique that uses learnable weighting functions to combine Cartesian, polar, and intensity information, enhancing the ability of the model to distinguish between objects with similar geometries but different material properties and 2) a dynamic decoder depth (DDD) mechanism that adapts to the complexity of each scene, optimizing the tradeoff between accuracy and computational efficiency. Extensive experiments on …"
         },
         {
-          "title": "TSSTDet: Transformation-based 3-D object detection via a spatial shape transformer",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:S16KYo8Pm5AC",
-          "citation": "HA Hoang, DC Bui, M Yoo - IEEE sensors journal 24 (5), 7126-7139, 2024, 2024",
-          "cited_by": 38,
-          "venue": "IEEE sensors journal 24 (5), 7126-7139",
-          "authors": "HA Hoang, DC Bui, M Yoo",
-          "description": "Accurately detecting and understanding the shapes of objects in 3-D scenes are essential for autonomous driving. In a 3-D scene, objects are distributed with various incomplete shapes and rotations. Determining the shape allows for a comprehensive understanding of an object’s dimensions, rotations, and spatial relationships with its surroundings. Traditional detection methods do not explicitly consider the rotations and complete shapes that objects can assume. Consequently, these methods require large networks and extensive data augmentation to detect accurately. Taking advantage of the vision-transformer (ViT), we introduce an efficient transformer-based 3-D detector called transformation-based 3-D object detection via a spatial shape transformer (TSSTDet) to address these challenges. We constructed TSSTDet as a multistage detector based on a light detection and ranging (LiDAR) point cloud …"
-        },
-        {
-          "title": "CAMTrack: a combined appearance-motion method for multiple-object tracking",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:xtoqd-5pKcoC",
-          "citation": "DC Bui, NL Nguyen, AH Hoang, M Yoo - Machine Vision and Applications 35 (4), 62, 2024, 2024",
-          "cited_by": 9,
-          "venue": "Machine Vision and Applications 35 (4), 62",
-          "authors": "DC Bui, NL Nguyen, AH Hoang, M Yoo",
-          "description": "Object tracking has emerged as an essential process for various applications in the field of computer vision, such as autonomous driving. Recently, object tracking technology has experienced rapid growth, particularly its applications in self-driving vehicles. Tracking systems typically follow the detection-based tracking paradigm, which is affected by the detection results. Although deep learning has led to significant improvements in object detection, data association remains dependent on factors such as spatial location, motion, and appearance, to associate new observations with existing tracks. In this study, we introduce a novel approach called Combined Appearance-Motion Tracking (CAMTrack) to enhance data association by integrating object appearances and their corresponding movements. The proposed tracking method utilizes an appearance-motion model using an appearance-affinity network and an …"
-        },
-        {
-          "title": "Federated learning-based service caching in multi-access edge computing system",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:e_rmSamDkqQC",
-          "citation": "TP Tran, AHN Tran, TM Nguyen, M Yoo - Applied Sciences 14 (1), 401, 2024, 2024",
-          "cited_by": 9,
-          "venue": "Applied Sciences 14 (1), 401",
-          "authors": "TP Tran, AHN Tran, TM Nguyen, M Yoo",
-          "description": "Multi-access edge computing (MEC) brings computations closer to mobile users, thereby decreasing service latency and providing location-aware services. Nevertheless, given the constrained resources of the MEC server, it is crucial to provide a limited number of services that properly fulfill the demands of users. Several static service caching approaches have been proposed. However, the effectiveness of these strategies is constrained by the dynamic nature of the system states and user demand patterns. To mitigate this problem, several investigations have been conducted on dynamic service caching techniques that can be categorized as centralized and distributed. However, centralized approaches typically require gathering comprehensive data from the entire system. This increases the burden on resources and raises concerns regarding data security and privacy. By contrast, distributed strategies require the formulation of complicated optimization problems without leveraging the inherent characteristics of the data. This paper proposes a distributed service caching strategy based on federated learning (SCFL) that works efficiently in a distributed system with user mobility. An autoencoder model is utilized to extract features regarding the service request distribution of individual MEC servers. The global model is then generated using federated learning, which is utilized to make service-caching decisions. Extensive experiments are conducted to demonstrate that the performance of the proposed method is superior to that of other methods."
+          "title": "Instance embedding as queries for detr-based LiDAR panoptic segmentation",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:ClCfbGk0d_YC",
+          "citation": "NQ Ha-Phan, HV Vuong, M Yoo - IEEE Transactions on Intelligent Vehicles, 2024, 2024",
+          "cited_by": 2,
+          "venue": "IEEE Transactions on Intelligent Vehicles",
+          "authors": "NQ Ha-Phan, HV Vuong, M Yoo",
+          "description": "LiDAR panoptic segmentation (LPS) offers a comprehensive perception of the driving environment for autonomous vehicles, providing valuable and relevant information for downstream tasks such as scene understanding or 4D panoptic tracking. Current state-of-the-art (SOTA) methods are predominantly based on the detection-transformer (DETR) paradigm. These approaches formulate panoptic segmentation as a problem of predicting the association scores of points within each group, which can be either a thing class instance or a stuff class. To this end, groups are represented by a fixed number of randomly initialized vectors called queries, whose values remain constant during inference. In this approach, queries are required to represent a wide range of objects that present in any particular scene. Recent studies on DETR application in the image domain have attempted to resolve this issue by introducing a …"
         },
         {
           "title": "Traffic flow prediction in 5G-enabled intelligent transportation systems using parameter optimization and adaptive model selection",
@@ -136,6 +118,15 @@
           "venue": "Sensors 24 (20), 6529",
           "authors": "HHP Vo, TM Nguyen, KA Bui, M Yoo",
           "description": "This study proposes a novel hybrid method, FVMD-WOA-GA, for enhancing traffic flow prediction in 5G-enabled intelligent transportation systems. The method integrates fast variational mode decomposition (FVMD) with optimization techniques, namely, the whale optimization algorithm (WOA) and genetic algorithm (GA), to improve the accuracy of overall traffic flow based on models tailored for each decomposed sub-sequence. The selected predictive models—long short-term memory (LSTM), bidirectional LSTM (BiLSTM), gated recurrent unit (GRU), and bidirectional GRU (BiGRU)—were considered to capture diverse temporal dependencies in traffic data. This research explored a multi-stage approach, where the decomposition, optimization, and selection of models are performed systematically to improve prediction performance. Experimental validation on two real-world traffic datasets further underscores the method’s efficacy, achieving root mean squared errors (RMSEs) of 152.43 and 7.91 on the respective datasets, which marks improvements of 3.44% and 12.87% compared to the existing methods. These results highlight the ability of the FVMD-WOA-GA approach to improve prediction accuracy significantly, reduce inference time, enhance system adaptability, and contribute to more efficient traffic management."
+        },
+        {
+          "title": "CAMTrack: a combined appearance-motion method for multiple-object tracking",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:xtoqd-5pKcoC",
+          "citation": "DC Bui, NL Nguyen, AH Hoang, M Yoo - Machine Vision and Applications 35 (4), 62, 2024, 2024",
+          "cited_by": 9,
+          "venue": "Machine Vision and Applications 35 (4), 62",
+          "authors": "DC Bui, NL Nguyen, AH Hoang, M Yoo",
+          "description": "Object tracking has emerged as an essential process for various applications in the field of computer vision, such as autonomous driving. Recently, object tracking technology has experienced rapid growth, particularly its applications in self-driving vehicles. Tracking systems typically follow the detection-based tracking paradigm, which is affected by the detection results. Although deep learning has led to significant improvements in object detection, data association remains dependent on factors such as spatial location, motion, and appearance, to associate new observations with existing tracks. In this study, we introduce a novel approach called Combined Appearance-Motion Tracking (CAMTrack) to enhance data association by integrating object appearances and their corresponding movements. The proposed tracking method utilizes an appearance-motion model using an appearance-affinity network and an …"
         },
         {
           "title": "Multi‐agent trajectory prediction with adaptive perception‐guided transformers",
@@ -156,22 +147,13 @@
           "description": "Real-time multiple object tracking plays a pivotal role in autonomous driving applications, particularly in real-world applications. Current methods in various domains often face an inherent trade-off between accuracy and speed. This dilemma arises from the need to achieve high precision, which tends to entail the development of more intricate models. However, these complex models often incur a high processing overhead. In this study, we introduced an Attention-based Feature Matching tracker for multiple-object tracking, named AFMTrack. We developed AFMTrack as a Transformer-based tracking method that improves speed and accuracy to provide a comprehensive solution to real-time tracking challenges. In particular, we designed a feature-matching module, which is a multi-layer attention-based network, to produce an association matrix by learning the correspondence between frames. Furthermore, in …"
         },
         {
-          "title": "Mobility-aware service migration in MEC system",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:0N-VGjzr574C",
-          "citation": "TP Tran, M Yoo - 2024 International Conference on Information Networking (ICOIN), 653-656, 2024, 2024",
-          "cited_by": 3,
-          "venue": "2024 International Conference on Information Networking (ICOIN), 653-656",
-          "authors": "TP Tran, M Yoo",
-          "description": "Multi-access edge computing (MEC) has emerged as an effective approach for enhancing system quality. Nevertheless, the movement of users and variations in demand for the service might lead to an increase in system delays. This article investigates the issue of service migration, with a particular focus on the factors of mobility and service availability. Specifically, we model the Markov Decision Process (MDP) problem. To make effective service migration decisions, we propose a deep reinforcement learning (DRL) model. Furthermore, a recurrent neural network (RNN) is implemented in order to enhance model performance by predicting user movement. The experimental results demonstrate the effectiveness of the proposed method in reducing the system delay."
-        },
-        {
-          "title": "Instance embedding as queries for detr-based LiDAR panoptic segmentation",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:ClCfbGk0d_YC",
-          "citation": "NQ Ha-Phan, HV Vuong, M Yoo - IEEE Transactions on Intelligent Vehicles, 2024, 2024",
-          "cited_by": 2,
-          "venue": "IEEE Transactions on Intelligent Vehicles",
-          "authors": "NQ Ha-Phan, HV Vuong, M Yoo",
-          "description": "LiDAR panoptic segmentation (LPS) offers a comprehensive perception of the driving environment for autonomous vehicles, providing valuable and relevant information for downstream tasks such as scene understanding or 4D panoptic tracking. Current state-of-the-art (SOTA) methods are predominantly based on the detection-transformer (DETR) paradigm. These approaches formulate panoptic segmentation as a problem of predicting the association scores of points within each group, which can be either a thing class instance or a stuff class. To this end, groups are represented by a fixed number of randomly initialized vectors called queries, whose values remain constant during inference. In this approach, queries are required to represent a wide range of objects that present in any particular scene. Recent studies on DETR application in the image domain have attempted to resolve this issue by introducing a …"
+          "title": "Enhancing intrusion detection in wireless sensor networks using a GSWO-CatBoost approach",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:q3CdL3IzO_QC",
+          "citation": "TM Nguyen, HHP Vo, M Yoo - Sensors 24 (11), 3339, 2024, 2024",
+          "cited_by": 44,
+          "venue": "Sensors 24 (11), 3339",
+          "authors": "TM Nguyen, HHP Vo, M Yoo",
+          "description": "Intrusion detection systems (IDSs) in wireless sensor networks (WSNs) rely heavily on effective feature selection (FS) for enhanced efficacy. This study proposes a novel approach called Genetic Sacrificial Whale Optimization (GSWO) to address the limitations of conventional methods. GSWO combines a genetic algorithm (GA) and whale optimization algorithms (WOA) modified by applying a new three-population division strategy with a proposed conditional inherited choice (CIC) to overcome premature convergence in WOA. The proposed approach achieves a balance between exploration and exploitation and enhances global search abilities. Additionally, the CatBoost model is employed for classification, effectively handling categorical data with complex patterns. A new technique for fine-tuning CatBoost’s hyperparameters is introduced, using effective quantization and the GSWO strategy. Extensive experimentation on various datasets demonstrates the superiority of GSWO-CatBoost, achieving higher accuracy rates on the WSN-DS, WSNBFSF, NSL-KDD, and CICIDS2017 datasets than the existing approaches. The comprehensive evaluations highlight the real-time applicability and accuracy of the proposed method across diverse data sources, including specialized WSN datasets and established benchmarks. Specifically, our GSWO-CatBoost method has an inference time nearly 100 times faster than deep learning methods while achieving high accuracy rates of 99.65%, 99.99%, 99.76%, and 99.74% for WSN-DS, WSNBFSF, NSL-KDD, and CICIDS2017, respectively."
         },
         {
           "title": "Weighted robust tensor principal component analysis for the recovery of complex corrupted data in a 5g-enabled internet of things",
@@ -183,15 +165,6 @@
           "description": "Technological developments coupled with socioeconomic changes are driving a rapid transformation of the fifth-generation (5G) cellular network landscape. This evolution has led to versatile applications with fast data-transfer capabilities. The integration of 5G with wireless sensor networks (WSNs) has rendered the Internet of Things (IoTs) crucial for measurement and sensing. Although 5G-enabled IoTs are vital, they face challenges in data integrity, such as mixed noise, outliers, and missing values, owing to various transmission issues. Traditional methods such as the tensor robust principal component analysis (TRPCA) have limitations in preserving essential data. This study introduces an enhanced approach, the weighted robust tensor principal component analysis (WRTPCA), combined with weighted tensor completion (WTC). The new method enhances data recovery using tensor singular value decomposition (t-SVD) to separate regular and abnormal data, preserve significant components, and robustly address complex data corruption issues, such as mixed noise, outliers, and missing data, with the globally optimal solution determined through the alternating direction method of multipliers (ADMM). Our study is the first to address complex corruption in multivariate data using the WTRPCA. The proposed approach outperforms current techniques. In all corrupted scenarios, the normalized mean absolute error (NMAE) of the proposed method is typically less than 0.2, demonstrating strong performance even in the most challenging conditions in which other models struggle. This highlights the effectiveness of the proposed approach in real …"
         },
         {
-          "title": "LiDAR Panoptic Segmentation With Learnable Embeddings and Dynamic Decoder",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:hCrLmN-GePgC",
-          "citation": "NL Nguyen, M Yoo - IEEE Sensors Journal 25 (1), 2019-2029, 2024, 2024",
-          "cited_by": 0,
-          "venue": "IEEE Sensors Journal 25 (1), 2019-2029",
-          "authors": "NL Nguyen, M Yoo",
-          "description": "Light detection and ranging (LiDAR) panoptic segmentation is a crucial task for autonomous driving, enabling comprehensive scene understanding by unifying semantic and instance segmentation. However, existing methods face challenges in effectively utilizing available information when constructing positional embeddings (PEs) and adapting to varying scene complexities. This article presents a novel approach to addressing these limitations. We introduce two key innovations: 1) an improved PE technique that uses learnable weighting functions to combine Cartesian, polar, and intensity information, enhancing the ability of the model to distinguish between objects with similar geometries but different material properties and 2) a dynamic decoder depth (DDD) mechanism that adapts to the complexity of each scene, optimizing the tradeoff between accuracy and computational efficiency. Extensive experiments on …"
-        },
-        {
           "title": "Detailed-view Autonomous Vehicle Trajectory Prediction with Stratified Transformers",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:ruyezt5ZtCIC",
           "citation": "NL Nguyen, M Yoo - 전자공학회논문지 61 (4), 3-9, 2024, 2024",
@@ -199,6 +172,15 @@
           "venue": "전자공학회논문지 61 (4), 3-9",
           "authors": "NL Nguyen, M Yoo",
           "description": "자율 주행 차량의 궤적을 정확하게 예측하는 것은 안전한 주행을 보장하는 데 필수적이지만 멀티모달 미래 궤적을 예측하는 것은 어려울 수 있다. 어텐션과 트랜스포머와 같은 최근의 접근 방식은 에이전트 상호 작용과 지도 문맥를 고려하여 최첨단 성능을 달성하였다. 본 연구에서는 트랜스포머를 사용한 에이전트 중심 접근 방식을 사용하여 환경에 대한 포괄적인 이해를 제공하는 궤적 예측에 초점을 맞추었다. 제안한 접근 방식은 주변 에이전트나 차선을 레벨로 배치하고 각 레벨의 정보를 인코딩하는 상세뷰 공간 컨텍스트 인코딩을 도입하여 복잡한 공간 관계를 효율적으로 인코딩할 수 있다. 제안 궤적 예측 기법에 트랜스포머 모델을 적용하였다. 제안 기법은 아르고버스 벤치마크에서 평가되었으며 정확도 측면에서 최첨단 기법 대비 우수함을 보였다."
+        },
+        {
+          "title": "Mobility-aware service migration in MEC system",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:0N-VGjzr574C",
+          "citation": "TP Tran, M Yoo - 2024 International Conference on Information Networking (ICOIN), 653-656, 2024, 2024",
+          "cited_by": 3,
+          "venue": "2024 International Conference on Information Networking (ICOIN), 653-656",
+          "authors": "TP Tran, M Yoo",
+          "description": "Multi-access edge computing (MEC) has emerged as an effective approach for enhancing system quality. Nevertheless, the movement of users and variations in demand for the service might lead to an increase in system delays. This article investigates the issue of service migration, with a particular focus on the factors of mobility and service availability. Specifically, we model the Markov Decision Process (MDP) problem. To make effective service migration decisions, we propose a deep reinforcement learning (DRL) model. Furthermore, a recurrent neural network (RNN) is implemented in order to enhance model performance by predicting user movement. The experimental results demonstrate the effectiveness of the proposed method in reducing the system delay."
         },
         {
           "title": "ESSDet: Enhancing Spatial Shape for 3-D Object Detection",
@@ -210,6 +192,15 @@
           "description": "Recently, point cloud 3-D object detection has attracted a lot of interest and developed into a vital area of research for the 3-D computer vision community, including robotics and autonomous driving. The capacity to perceive 3-D space is essential for self-driving cars to understand the vehicle’s surroundings, enabling subsequent systems to respond appropriately. However, 3-D spatial objects frequently exhibit shape imperfections attributed to diverse outdoor factors. To overcome this problem, we present ESSDet, a novel LiDAR-based 3-D object detection model, which enhances the perception of object shape in 3-D space. ESSDet first reproduces the 3-D point cloud geometry of the occluded object by using a deep learning network. Subsequently, our model is trained to estimate the spatial occupancy, signifying whether a given region encompasses object shapes."
         },
         {
+          "title": "TSSTDet: Transformation-based 3-D object detection via a spatial shape transformer",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:S16KYo8Pm5AC",
+          "citation": "HA Hoang, DC Bui, M Yoo - IEEE sensors journal 24 (5), 7126-7139, 2024, 2024",
+          "cited_by": 38,
+          "venue": "IEEE sensors journal 24 (5), 7126-7139",
+          "authors": "HA Hoang, DC Bui, M Yoo",
+          "description": "Accurately detecting and understanding the shapes of objects in 3-D scenes are essential for autonomous driving. In a 3-D scene, objects are distributed with various incomplete shapes and rotations. Determining the shape allows for a comprehensive understanding of an object’s dimensions, rotations, and spatial relationships with its surroundings. Traditional detection methods do not explicitly consider the rotations and complete shapes that objects can assume. Consequently, these methods require large networks and extensive data augmentation to detect accurately. Taking advantage of the vision-transformer (ViT), we introduce an efficient transformer-based 3-D detector called transformation-based 3-D object detection via a spatial shape transformer (TSSTDet) to address these challenges. We constructed TSSTDet as a multistage detector based on a light detection and ranging (LiDAR) point cloud …"
+        },
+        {
           "title": "Deep Learning-Based Approaches for Nucleus Segmentation",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:i2xiXl-TujoC",
           "citation": "DC Bui - 한국통신학회논문지 49 (4), 620-629, 2024, 2024",
@@ -217,30 +208,21 @@
           "venue": "한국통신학회논문지 49 (4), 620-629",
           "authors": "DC Bui",
           "description": "The accurate identification of cell nuclei is a critical aspect of various analyses, given that human cells, numbering around 30 trillion, contain DNA as their genetic code. In this research paper, we provide a comprehensive overview of deep learning-based techniques for nucleus segmentation. We have replicated and assessed the state-of-the-art methods using datasets like FCN, SegNet, U-net, and DoubleU-net, with a focus on the Data Science Bowl 2018 dataset comprising 670 training data folders and 65 testing data folders. Our experimental findings reveal that DoubleU-Net surpasses U-Net and other baseline models, yielding more precise segmentation masks. This promising outcome suggests that DoubleU-Net could serve as a robust model for addressing various challenges in medical image segmentation."
+        },
+        {
+          "title": "Federated learning-based service caching in multi-access edge computing system",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:e_rmSamDkqQC",
+          "citation": "TP Tran, AHN Tran, TM Nguyen, M Yoo - Applied Sciences 14 (1), 401, 2024, 2024",
+          "cited_by": 9,
+          "venue": "Applied Sciences 14 (1), 401",
+          "authors": "TP Tran, AHN Tran, TM Nguyen, M Yoo",
+          "description": "Multi-access edge computing (MEC) brings computations closer to mobile users, thereby decreasing service latency and providing location-aware services. Nevertheless, given the constrained resources of the MEC server, it is crucial to provide a limited number of services that properly fulfill the demands of users. Several static service caching approaches have been proposed. However, the effectiveness of these strategies is constrained by the dynamic nature of the system states and user demand patterns. To mitigate this problem, several investigations have been conducted on dynamic service caching techniques that can be categorized as centralized and distributed. However, centralized approaches typically require gathering comprehensive data from the entire system. This increases the burden on resources and raises concerns regarding data security and privacy. By contrast, distributed strategies require the formulation of complicated optimization problems without leveraging the inherent characteristics of the data. This paper proposes a distributed service caching strategy based on federated learning (SCFL) that works efficiently in a distributed system with user mobility. An autoencoder model is utilized to extract features regarding the service request distribution of individual MEC servers. The global model is then generated using federated learning, which is utilized to make service-caching decisions. Extensive experiments are conducted to demonstrate that the performance of the proposed method is superior to that of other methods."
         }
       ]
     },
     {
       "year": 2023,
       "entries": [
-        {
-          "title": "Deep reinforcement learning-based task offloading and resource allocation for industrial IoT in MEC federation system",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:k8Z6L05lTy4C",
-          "citation": "HM Do, TP Tran, M Yoo - IEEe Access 11, 83150-83170, 2023, 2023",
-          "cited_by": 50,
-          "venue": "IEEe Access 11, 83150-83170",
-          "authors": "HM Do, TP Tran, M Yoo",
-          "description": "The rapid growth of the Internet of Things (IoT) has resulted in the development of intelligent industrial systems known as Industrial IoT (IIoT). These systems integrate smart devices, sensors, cameras, and 5G technologies to enable automated data gathering and analysis boost production efficiency and overcome scalability issues. However, IoT devices have limited computer power, memory, and battery capacities. To address these challenges, mobile edge computing (MEC) has been introduced to IIoT systems to reduce the computational burden on the devices. While the dedicated MEC paradigm limits optimal resource utilization and load balancing, the MEC federation can potentially overcome these drawbacks. However, previous studies have relied on idealized assumptions when developing optimal models, raising concerns about their practical applicability. In this study, we investigated the joint decision …"
-        },
-        {
-          "title": "3ONet: 3-D detector for occluded object under obstructed conditions",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:lmc2jWPfTJgC",
-          "citation": "HA Hoang, M Yoo - IEEE Sensors Journal 23 (16), 18879-18892, 2023, 2023",
-          "cited_by": 33,
-          "venue": "IEEE Sensors Journal 23 (16), 18879-18892",
-          "authors": "HA Hoang, M Yoo",
-          "description": "The ability to perceive and understand 3-D space is crucial for autonomous driving to effectively navigate their surroundings and make informed decisions. However, deep learning on point clouds is currently in its early stages due to the unique challenges of processing such data with deep neural networks. One of the major challenges lies in accurately detecting partially occluded objects under various practical conditions. To address this problem, we propose 3-D detector for Occluded Object under Obstructed conditions (3ONet), a two-stage light detection and ranging (LiDAR)-based 3-D object detection framework. Leveraging the advantages of the point-voxel-based method, 3ONet efficiently encodes multiscale features, enabling the generation of high-quality 3-D proposals while preserving detailed object shape information. Specifically, we introduce a point reconstruction network module designed to recover …"
-        },
         {
           "title": "DoS attack detection using online learning techniques in wireless sensor networks",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:WZBGuue-350C",
@@ -258,6 +240,15 @@
           "venue": "2023 International Conference on Advanced Technologies for Communications …",
           "authors": "TN Thi, TH Do, M Yoo",
           "description": "This paper describes an OCR system for extracting information on Vietnamese book cover images. The set system takes as input the book cover image and outputs the book title, author, publisher and other information. The system is composed of three modules including text detection, text recognition and information synthesis. For the text detection module, we experiment with EAST and SAST models. For the text recognition module, we experimented with CRNN, SVTR, Transformer OCR models. In the last step, we use Yolov4 for object detection then to process the information. Our system extracts book cover information with accuracy per word up to 84.06% and on WER and CER score respectively 22.67% and 22.41%."
+        },
+        {
+          "title": "Weighted Tensor Robust Principal Component Analysis to Reduce Noise in Wireless Sensor Networks",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:foquWX3nUaYC",
+          "citation": "HHP Vo, M Yoo - 2023 14th International Conference on Information and Communication …, 2023, 2023",
+          "cited_by": 0,
+          "venue": "2023 14th International Conference on Information and Communication …",
+          "authors": "HHP Vo, M Yoo",
+          "description": "This paper introduces a solution for reducing noise data in wireless sensor networks employing a weighted tensor robust principal component analysis (WTRPCA) approach. The proposed method effectively separates the data into normal and abnormal tensors, facilitating identifying corruption and preserving key data components. WTRPCA is specifically designed to optimize this reduced process, and experimental results demonstrate its superior accuracy compared to existing approaches."
         },
         {
           "title": "Delay Optimization for Augmented Reality Service using Mobile Edge Computing Federation System",
@@ -278,31 +269,13 @@
           "description": "Maintaining data dependability within wireless sensor network (WSN) systems has significant importance. Nevertheless, the deployment of systems in unattended and hostile areas poses a major challenge in dealing with noise. Consequently, several investigations have been conducted to address the issue of noise-affected data recovery. Nevertheless, previous research has primarily focused on the internal noise of the system. Neglecting to include external factors that impact the WSN system in the study might lead to findings that are not true to reality. Hence, this research takes into account both internal and external noise factors, such as rain, fog, or snow conditions. Moreover, in order to maintain the temporal characteristics and intersensor relationships, the data from multiple sensor nodes are consolidated into a two-dimensional matrix format. The stacked convolutional autoencoder (SCAE) model is proposed, which has the capability to extract data features. The stack design of the SCAE enables it to effectively mitigate the issue of vanishing gradients. Moreover, the weight sharing approach used between the two subnetworks also enhances the efficiency of the weight initialization procedure. Thorough experiments are conducted using both simulated WSN systems and real-world sensing data. Experimental results demonstrate that the SCAE outperforms existing methods for reconstructing noisy data."
         },
         {
-          "title": "Noise Reduction Caused by External Events in Wireless Sensor Network",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:hMsQuOkrut0C",
-          "citation": "TT Lai, J Cho, M Yoo - 2023 International Conference on Information Networking (ICOIN), 541-544, 2023, 2023",
-          "cited_by": 2,
-          "venue": "2023 International Conference on Information Networking (ICOIN), 541-544",
-          "authors": "TT Lai, J Cho, M Yoo",
-          "description": "Reliable communication always is an essential critical and challenging task in wireless sensor networks (WSNs). Despite this, WSNs models are prone to disrupting the normal working state because most WSN models are deployed in unattended hostile environments. To ensure secure data processing in a WSNs, many techniques have been proposed to protect data privacy when data are transferred from sensors to base stations. This article focuses on reducing noise, which occurs due to external events, such as harsh weather conditions. We reconstruct the data, which is affected by noise, by using a convolutional autoencoder network. The performance was evaluated in terms of error, and it was proven to be competitive."
-        },
-        {
-          "title": "Shape Aware for 3D Object Detection using LiDAR Point Cloud",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:TIZ-Mc8IlK0C",
-          "citation": "HA Hoang, M Yoo - 한국통신학회 학술대회논문집, 1836-1837, 2023, 2023",
-          "cited_by": 1,
-          "venue": "한국통신학회 학술대회논문집, 1836-1837",
-          "authors": "HA Hoang, M Yoo",
-          "description": "Point cloud 3D object detection has gained significant attention in the 3D computer vision community, specifically in autonomous driving and robotics. However, detecting 3D objects in LiDAR is still challenging due to the complexity of point clouds. Deep learning, a prominent AI technique, has been successful in solving 2D vision problems but is still in its early stages for point clouds. To address this challenge, we propose a robust neural network for 3D object detection using point clouds."
-        },
-        {
-          "title": "Weighted Tensor Robust Principal Component Analysis to Reduce Noise in Wireless Sensor Networks",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:foquWX3nUaYC",
-          "citation": "HHP Vo, M Yoo - 2023 14th International Conference on Information and Communication …, 2023, 2023",
-          "cited_by": 0,
-          "venue": "2023 14th International Conference on Information and Communication …",
-          "authors": "HHP Vo, M Yoo",
-          "description": "This paper introduces a solution for reducing noise data in wireless sensor networks employing a weighted tensor robust principal component analysis (WTRPCA) approach. The proposed method effectively separates the data into normal and abnormal tensors, facilitating identifying corruption and preserving key data components. WTRPCA is specifically designed to optimize this reduced process, and experimental results demonstrate its superior accuracy compared to existing approaches."
+          "title": "Deep reinforcement learning-based task offloading and resource allocation for industrial IoT in MEC federation system",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:k8Z6L05lTy4C",
+          "citation": "HM Do, TP Tran, M Yoo - IEEe Access 11, 83150-83170, 2023, 2023",
+          "cited_by": 50,
+          "venue": "IEEe Access 11, 83150-83170",
+          "authors": "HM Do, TP Tran, M Yoo",
+          "description": "The rapid growth of the Internet of Things (IoT) has resulted in the development of intelligent industrial systems known as Industrial IoT (IIoT). These systems integrate smart devices, sensors, cameras, and 5G technologies to enable automated data gathering and analysis boost production efficiency and overcome scalability issues. However, IoT devices have limited computer power, memory, and battery capacities. To address these challenges, mobile edge computing (MEC) has been introduced to IIoT systems to reduce the computational burden on the devices. While the dedicated MEC paradigm limits optimal resource utilization and load balancing, the MEC federation can potentially overcome these drawbacks. However, previous studies have relied on idealized assumptions when developing optimal models, raising concerns about their practical applicability. In this study, we investigated the joint decision …"
         },
         {
           "title": "Method and apparatus for patch gan-based depth completion in autonomous vehicles",
@@ -314,6 +287,15 @@
           "description": "2023-01-19 Assigned to FOUNDATION OF SOONGSIL UNIVERSITY-INDUSTRY COOPERATION reassignment FOUNDATION OF SOONGSIL UNIVERSITY-INDUSTRY COOPERATION ASSIGNMENT OF ASSIGNORS INTEREST (SEE DOCUMENT FOR DETAILS). Assignors: NGUYEN, MINH TRI, YOO, MYUNG SIK"
         },
         {
+          "title": "3ONet: 3-D detector for occluded object under obstructed conditions",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:lmc2jWPfTJgC",
+          "citation": "HA Hoang, M Yoo - IEEE Sensors Journal 23 (16), 18879-18892, 2023, 2023",
+          "cited_by": 33,
+          "venue": "IEEE Sensors Journal 23 (16), 18879-18892",
+          "authors": "HA Hoang, M Yoo",
+          "description": "The ability to perceive and understand 3-D space is crucial for autonomous driving to effectively navigate their surroundings and make informed decisions. However, deep learning on point clouds is currently in its early stages due to the unique challenges of processing such data with deep neural networks. One of the major challenges lies in accurately detecting partially occluded objects under various practical conditions. To address this problem, we propose 3-D detector for Occluded Object under Obstructed conditions (3ONet), a two-stage light detection and ranging (LiDAR)-based 3-D object detection framework. Leveraging the advantages of the point-voxel-based method, 3ONet efficiently encodes multiscale features, enabling the generation of high-quality 3-D proposals while preserving detailed object shape information. Specifically, we introduce a point reconstruction network module designed to recover …"
+        },
+        {
           "title": "Energy Consumption Optimization in Mobile Edge Computing Federation based Deep Reinforcement Learning",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:M7yex6snE4oC",
           "citation": "HM Do, M Yoo - 한국통신학회 학술대회논문집, 1834-1835, 2023, 2023",
@@ -321,6 +303,15 @@
           "venue": "한국통신학회 학술대회논문집, 1834-1835",
           "authors": "HM Do, M Yoo",
           "description": "The collaboration of MEC systems is now necessary for MEC service providers to handle service continuity in multi-operator operating scenarios. The so-called MEC federation is a type of collaboration. This report provides background information on MEC federation systems' best practices for resource allocation and energy use. The minimization problem is resolved using a Deep Reinforcement Learning approach called Deep Deterministic Policy Gradient. The simulation was also put up to gauge how well our suggestion worked."
+        },
+        {
+          "title": "Shape Aware for 3D Object Detection using LiDAR Point Cloud",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:TIZ-Mc8IlK0C",
+          "citation": "HA Hoang, M Yoo - 한국통신학회 학술대회논문집, 1836-1837, 2023, 2023",
+          "cited_by": 1,
+          "venue": "한국통신학회 학술대회논문집, 1836-1837",
+          "authors": "HA Hoang, M Yoo",
+          "description": "Point cloud 3D object detection has gained significant attention in the 3D computer vision community, specifically in autonomous driving and robotics. However, detecting 3D objects in LiDAR is still challenging due to the complexity of point clouds. Deep learning, a prominent AI technique, has been successful in solving 2D vision problems but is still in its early stages for point clouds. To address this challenge, we propose a robust neural network for 3D object detection using point clouds."
         },
         {
           "title": "Method and apparatus for managing a yaml file for kubernetes",
@@ -339,21 +330,21 @@
           "venue": "한국통신학회 학술대회논문집, 185-188",
           "authors": "TNH Anh, M Yoo",
           "description": "The expansion of 5G technology recently leads to the develop of Multi-Access Edge Network (MEC) as a potential solution to achieve the quality of service (QoS) of applications inside user devices (UDs). This article proposes a method in which MEC servers (MECSs) can communicate together, all receive the decision from MEC controller about how to sharing the resource to achieve the optimal processing delay of all QoS classes. This problem can be solved by proposed Deep Deterministic Policy Gradient (DDPG) framework."
+        },
+        {
+          "title": "Noise Reduction Caused by External Events in Wireless Sensor Network",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:hMsQuOkrut0C",
+          "citation": "TT Lai, J Cho, M Yoo - 2023 International Conference on Information Networking (ICOIN), 541-544, 2023, 2023",
+          "cited_by": 2,
+          "venue": "2023 International Conference on Information Networking (ICOIN), 541-544",
+          "authors": "TT Lai, J Cho, M Yoo",
+          "description": "Reliable communication always is an essential critical and challenging task in wireless sensor networks (WSNs). Despite this, WSNs models are prone to disrupting the normal working state because most WSN models are deployed in unattended hostile environments. To ensure secure data processing in a WSNs, many techniques have been proposed to protect data privacy when data are transferred from sensors to base stations. This article focuses on reducing noise, which occurs due to external events, such as harsh weather conditions. We reconstruct the data, which is affected by noise, by using a convolutional autoencoder network. The performance was evaluated in terms of error, and it was proven to be competitive."
         }
       ]
     },
     {
       "year": 2022,
       "entries": [
-        {
-          "title": "An efficient multivariate autoscaling framework using bi-lstm for cloud computing",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:BUYA1_V_uYcC",
-          "citation": "NM Dang-Quang, M Yoo - Applied sciences 12 (7), 3523, 2022, 2022",
-          "cited_by": 39,
-          "venue": "Applied sciences 12 (7), 3523",
-          "authors": "NM Dang-Quang, M Yoo",
-          "description": "With the rapid development of 5G technology, the need for a flexible and scalable real-time system for data processing has become increasingly important. By predicting future resource workloads, cloud service providers can automatically provision and deprovision user resources for the system beforehand, to meet service level agreements. However, workload demands fluctuate continuously over time, which makes their prediction difficult. Hence, several studies have proposed a technique called time series forecasting to accurately predict the resource workload. However, most of these studies focused solely on univariate time series forecasting; in other words, they only analyzed the measurement of a single feature. This study proposes an efficient multivariate autoscaling framework using bidirectional long short-term memory (Bi-LSTM) for cloud computing. The system framework was designed based on the monitor–analyze–plan–execute loop. The results obtained from our experiments on different actual workload datasets indicated that the proposed multivariate Bi-LSTM exhibited a root-mean-squared error (RMSE) prediction error 1.84-times smaller than that of the univariate one. Furthermore, it reduced the RMSE prediction error by 6.7% and 5.4% when compared with the multivariate LSTM and convolutional neural network-long short-term memory (CNN-LSTM) models, respectively. Finally, in terms of resource provisioning, the multivariate Bi-LSTM autoscaler was 47.2% and 14.7% more efficient than the multivariate LSTM and CNN-LSTM autoscalers, respectively."
-        },
         {
           "title": "CalibBD: Extrinsic calibration of the LiDAR and camera using a bidirectional neural network",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:EYYDruWGBe4C",
@@ -362,6 +353,15 @@
           "venue": "IEEE Access 10, 121261-121271",
           "authors": "AD Nguyen, M Yoo",
           "description": "With the rapid growth of self-driving vehicles, automobiles demand diverse data from multiple sensors to perceive the surrounding environment. Calibrating preprocessing between multiple sensors is necessary to utilize the data effectively. In particular, the LiDAR-camera pair, a suitable complement with 2D-3D information for each other, has been widely used in autonomous vehicles. Most traditional calibration methods require specific calibration targets set up under complicated environmental conditions, which require expensive human manual work. In this study, we propose a deep neural network that does not require any specific targets and offline setup to find the six degrees of freedom (6 DoF) transformation between LiDAR and the camera. Unlike previous deep learning CNN-based methods, which use raw 3D point clouds and 2D images frame by frame, CalibBD utilizes Bi-LSTM for sequence data to …"
+        },
+        {
+          "title": "Delay optimization in mobile edge computing federation using task offloading and resource allocation",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:vbGhcppDl1QC",
+          "citation": "HM Do, M Yoo - 2022 13th International Conference on Information and Communication …, 2022, 2022",
+          "cited_by": 3,
+          "venue": "2022 13th International Conference on Information and Communication …",
+          "authors": "HM Do, M Yoo",
+          "description": "In recent years, computation offloading has become an effective solution for limited resource issues. This article investigates decision offloading and computing resource allocation. We propose a task offloading framework to minimize the total delay considering the resource condition in the MEC federation system. Then, we also solve this problem by transferring to Markov Decision Process (MDP) and using the Deep Deterministic Policy Gradient (DDPG) framework. Simulation results show that the DDPG can successfully lower the delay of the tasks."
         },
         {
           "title": "LossDistillNet: 3D object detection in point cloud under harsh weather conditions",
@@ -373,6 +373,15 @@
           "description": "Recently, 3D object detection models have achieved very good performance under normal weather conditions, with the SE-SSD model having produced the highest performance by exchanging features between the teacher and student models. However, the performance of this model is significantly reduced by adverse weather conditions. Therefore, instead of training the teacher and student models simultaneously, we applied the knowledge distillation algorithm. In this algorithm, the teacher model is trained first by normal input, and the student model is then trained with distillation and student loss by adverse weather condition input. Although recent research has focused on combining different types of sensor inputs to enhance the original model’s performance in inclement weather, there are no studies that directly address the problem of missing points for point clouds. Accordingly, we applied a probability …"
         },
         {
+          "title": "Missvoxelnet: 3d object detection for autonomous vehicle in snow conditions",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:BwyfMAYsbu0C",
+          "citation": "A Do The, M Yoo - 2022 Thirteenth International Conference on Ubiquitous and Future Networks …, 2022, 2022",
+          "cited_by": 6,
+          "venue": "2022 Thirteenth International Conference on Ubiquitous and Future Networks …",
+          "authors": "A Do The, M Yoo",
+          "description": "LiDAR (Light Detection and Ranging) sensors are widely used in self-driving cars with awareness of the surrounding environment. However, the LiDAR sensor is sensitive to harsh weather conditions that cause the collected data to be distorted. These types of weather reduce the safety of self-driving cars. The harsh weather conditions also cause missing points problems on the point clouds, and it causes the performance of 3D object detection to reduce. Therefore, we propose a new method using probability estimation, which includes a Deep Mixture of Factor Analyzers (DMFA) and a Miss-Convolution layer, to recover missing points caused by snow. The proposed work outperforms models which perform well in normal conditions. In summary, snow often causes detection errors for 3D modern detectors. By recovering missing points in the point cloud, we significantly make the performance of the 3D detector better …"
+        },
+        {
           "title": "Improvement to LiDAR-camera extrinsic calibration by using 3D–3D correspondences",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:Z5m8FVwuT1cC",
           "citation": "AD Nguyen, TM Nguyen, M Yoo - Optik 259, 168917, 2022, 2022",
@@ -380,6 +389,24 @@
           "venue": "Optik 259, 168917",
           "authors": "AD Nguyen, TM Nguyen, M Yoo",
           "description": "In data fusion, calibration between 3D light detection and ranging (LiDAR) systems and cameras is one of the most fundamental tasks. We propose a calibration method to improve calibration accuracy by using a planar board. Most previous studies have attempted to find correspondences between 3D point clouds and 2D image pixels. In this study, a rigid transformation between LiDAR and camera was performed by exploiting the 3D–3D vertices and plane correspondences. First, the features, vertices and plane, are extracted from the camera and LiDAR, respectively. By compensating for the missing part of the 3D point cloud at the edges of the board, we improve the accuracy of the vertex estimation instead of only using the traditional RANSAC algorithm. Second, the rigid transformation is estimated by matching these 3D correspondences and refined by an ICP improvement. Finally, to evaluate the robustness of …"
+        },
+        {
+          "title": "CycleGAN-Based Depth Completion for Autonomous Vehicles",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:tYavs44e6CUC",
+          "citation": "MT Nguyen, M Yoo - 한국통신학회논문지 47 (5), 781-788, 2022, 2022",
+          "cited_by": 1,
+          "venue": "한국통신학회논문지 47 (5), 781-788",
+          "authors": "MT Nguyen, M Yoo",
+          "description": "Depth Completion은 자율 주행 차량에서 장면 이해 및 환경 인식 등을 지원하는 중요한 기술이다. 기존 방식은 두 센서의 상호 보완적 특성을 활용하기 위해 RGB 이미지와 Depth LIDAR 이미지와 같은 다중 모달 입력을 고려했다. 그러나 기존의 자동 인코더 접근 방식은 저차원 공간에서 데이터를 표현하는 데 한계가 있다. 또한 RGB 영상의 광 민감도로 인해 카메라 영상과 LIDAR 영상을 융합할 때 Depth의 불연속성이 발생한다. 본 연구에서는 고밀도의 Depth 재구성을 위해 픽셀 밀도 대신 데이터 분포를 학습하는 데 중점을 둔 CycleGAN을 적용하였다. 또한 Depth 불연속성 문제를 완화하기 위하여 Semantic Segmentation을 추가 입력으로 고려하였다. 제안된 방식은 다양한 도로 환경에서 획득된 동기화된 KITTI 벤치마크 데이터를 활용하여 훈련하고 평가하였다. 실험결과를 통해 제안된 방식이 Depth Completion의 성능과 효율 측면에서 우수함을 입증하였다."
+        },
+        {
+          "title": "An efficient multivariate autoscaling framework using bi-lstm for cloud computing",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:BUYA1_V_uYcC",
+          "citation": "NM Dang-Quang, M Yoo - Applied sciences 12 (7), 3523, 2022, 2022",
+          "cited_by": 39,
+          "venue": "Applied sciences 12 (7), 3523",
+          "authors": "NM Dang-Quang, M Yoo",
+          "description": "With the rapid development of 5G technology, the need for a flexible and scalable real-time system for data processing has become increasingly important. By predicting future resource workloads, cloud service providers can automatically provision and deprovision user resources for the system beforehand, to meet service level agreements. However, workload demands fluctuate continuously over time, which makes their prediction difficult. Hence, several studies have proposed a technique called time series forecasting to accurately predict the resource workload. However, most of these studies focused solely on univariate time series forecasting; in other words, they only analyzed the measurement of a single feature. This study proposes an efficient multivariate autoscaling framework using bidirectional long short-term memory (Bi-LSTM) for cloud computing. The system framework was designed based on the monitor–analyze–plan–execute loop. The results obtained from our experiments on different actual workload datasets indicated that the proposed multivariate Bi-LSTM exhibited a root-mean-squared error (RMSE) prediction error 1.84-times smaller than that of the univariate one. Furthermore, it reduced the RMSE prediction error by 6.7% and 5.4% when compared with the multivariate LSTM and convolutional neural network-long short-term memory (CNN-LSTM) models, respectively. Finally, in terms of resource provisioning, the multivariate Bi-LSTM autoscaler was 47.2% and 14.7% more efficient than the multivariate LSTM and CNN-LSTM autoscalers, respectively."
         },
         {
           "title": "Calibration-Net: LiDAR and camera auto-calibration using cost volume and convolutional neural network",
@@ -400,15 +427,6 @@
           "description": "The objective of depth completion is to generate a dense depth map by upsampling a sparse one. However, irregular sparse patterns or the lack of groundtruth data caused by unstructured data make depth completion extremely challenging. Sensor fusion using both RGB and LIDAR sensors can help produce a more reliable context with higher accuracy. Compared with previous approaches, this method takes semantic segmentation images as additional input and develops an unsupervised loss function. Thus, when combined with supervised depth loss, the depth completion problem is considered as semi-supervised learning. We used an adapted Wasserstein Generative Adversarial Network architecture instead of applying the traditional autoencoder approach and post-processing process to preserve valid depth measurements received from the input and further enhance the depth value precision of the results …"
         },
         {
-          "title": "Missvoxelnet: 3d object detection for autonomous vehicle in snow conditions",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:BwyfMAYsbu0C",
-          "citation": "A Do The, M Yoo - 2022 Thirteenth International Conference on Ubiquitous and Future Networks …, 2022, 2022",
-          "cited_by": 6,
-          "venue": "2022 Thirteenth International Conference on Ubiquitous and Future Networks …",
-          "authors": "A Do The, M Yoo",
-          "description": "LiDAR (Light Detection and Ranging) sensors are widely used in self-driving cars with awareness of the surrounding environment. However, the LiDAR sensor is sensitive to harsh weather conditions that cause the collected data to be distorted. These types of weather reduce the safety of self-driving cars. The harsh weather conditions also cause missing points problems on the point clouds, and it causes the performance of 3D object detection to reduce. Therefore, we propose a new method using probability estimation, which includes a Deep Mixture of Factor Analyzers (DMFA) and a Miss-Convolution layer, to recover missing points caused by snow. The proposed work outperforms models which perform well in normal conditions. In summary, snow often causes detection errors for 3D modern detectors. By recovering missing points in the point cloud, we significantly make the performance of the 3D detector better …"
-        },
-        {
           "title": "Patchgan-based depth completion in autonomous vehicle",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:uWiczbcajpAC",
           "citation": "T Nguyen, M Yoo - 2022 international conference on information networking (icoin), 498-501, 2022, 2022",
@@ -416,24 +434,6 @@
           "venue": "2022 international conference on information networking (icoin), 498-501",
           "authors": "T Nguyen, M Yoo",
           "description": "Depth completion is a challenging task and it serves as the fundamental function for many vision handling operation in autonomous vehicle. It aims to generate a dense depth map from upsampling the sparse input data collected from LIDAR sensor. This paper proposed a GAN architecture with a two-branch autoencoder in the generator that exploits two different modalities and performs a fusion strategy between two modalities. Furthermore, the architecture is evaluated on the KITTI datasets and KITTI benchmark and proved to have a competitive performance.."
-        },
-        {
-          "title": "Delay optimization in mobile edge computing federation using task offloading and resource allocation",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:vbGhcppDl1QC",
-          "citation": "HM Do, M Yoo - 2022 13th International Conference on Information and Communication …, 2022, 2022",
-          "cited_by": 3,
-          "venue": "2022 13th International Conference on Information and Communication …",
-          "authors": "HM Do, M Yoo",
-          "description": "In recent years, computation offloading has become an effective solution for limited resource issues. This article investigates decision offloading and computing resource allocation. We propose a task offloading framework to minimize the total delay considering the resource condition in the MEC federation system. Then, we also solve this problem by transferring to Markov Decision Process (MDP) and using the Deep Deterministic Policy Gradient (DDPG) framework. Simulation results show that the DDPG can successfully lower the delay of the tasks."
-        },
-        {
-          "title": "CycleGAN-Based Depth Completion for Autonomous Vehicles",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:tYavs44e6CUC",
-          "citation": "MT Nguyen, M Yoo - 한국통신학회논문지 47 (5), 781-788, 2022, 2022",
-          "cited_by": 1,
-          "venue": "한국통신학회논문지 47 (5), 781-788",
-          "authors": "MT Nguyen, M Yoo",
-          "description": "Depth Completion은 자율 주행 차량에서 장면 이해 및 환경 인식 등을 지원하는 중요한 기술이다. 기존 방식은 두 센서의 상호 보완적 특성을 활용하기 위해 RGB 이미지와 Depth LIDAR 이미지와 같은 다중 모달 입력을 고려했다. 그러나 기존의 자동 인코더 접근 방식은 저차원 공간에서 데이터를 표현하는 데 한계가 있다. 또한 RGB 영상의 광 민감도로 인해 카메라 영상과 LIDAR 영상을 융합할 때 Depth의 불연속성이 발생한다. 본 연구에서는 고밀도의 Depth 재구성을 위해 픽셀 밀도 대신 데이터 분포를 학습하는 데 중점을 둔 CycleGAN을 적용하였다. 또한 Depth 불연속성 문제를 완화하기 위하여 Semantic Segmentation을 추가 입력으로 고려하였다. 제안된 방식은 다양한 도로 환경에서 획득된 동기화된 KITTI 벤치마크 데이터를 활용하여 훈련하고 평가하였다. 실험결과를 통해 제안된 방식이 Depth Completion의 성능과 효율 측면에서 우수함을 입증하였다."
         },
         {
           "title": "Optimized placement of symmetrical service function chain in network function virtualization",
@@ -450,22 +450,13 @@
       "year": 2021,
       "entries": [
         {
-          "title": "Deep learning-based autoscaling using bidirectional long short-term memory for kubernetes",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:VLnqNzywnoUC",
-          "citation": "NM Dang-Quang, M Yoo - Applied Sciences 11 (9), 3835, 2021, 2021",
-          "cited_by": 97,
-          "venue": "Applied Sciences 11 (9), 3835",
+          "title": "A study on deep learning-based multivariate resource estimation with feature selection in cloud computing",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:vDijr-p_gm4C",
+          "citation": "NM Dang-Quang, M Yoo - 한국통신학회 학술대회논문집, 366-369, 2021, 2021",
+          "cited_by": 2,
+          "venue": "한국통신학회 학술대회논문집, 366-369",
           "authors": "NM Dang-Quang, M Yoo",
-          "description": "Presently, the cloud computing environment attracts many application developers to deploy their web applications on cloud data centers. Kubernetes, a well-known container orchestration for deploying web applications on cloud systems, offers an automatic scaling feature to meet clients’ ever-changing demands with the reactive approach. This paper proposes a system architecture based on Kubernetes with a proactive custom autoscaler using a deep neural network model to handle the workload during run time dynamically. The proposed system architecture is designed based on the Monitor–Analyze–Plan–Execute (MAPE) loop. The main contribution of this paper is the proactive custom autoscaler, which focuses on the analysis and planning phases. In analysis phase, Bidirectional Long Short-term Memory (Bi-LSTM) is applied to predict the number of HTTP workloads in the future. In the planning phase, a cooling-down time period is implemented to mitigate the oscillation problem. In addition, a resource removal strategy is proposed to remove a part of the resources when the workload decreases, so that the autoscaler can handle it faster when the burst of workload happens. Through experiments with two different realistic workloads, the Bi-LSTM model achieves better accuracy not only than the Long Short-Term Memory model but also than the state-of-the-art statistical auto-regression integrated moving average model in terms of short- and long-term forecasting. Moreover, it offers 530 to 600 times faster prediction speed than ARIMA models with different workloads. Furthermore, as compared to the LSTM model, the Bi-LSTM model …"
-        },
-        {
-          "title": "Multivariate deep learning model for workload prediction in cloud computing",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:0KyAp5RtaNEC",
-          "citation": "NM Dang-Quang, M Yoo - 2021 International Conference on Information and Communication Technology …, 2021, 2021",
-          "cited_by": 16,
-          "venue": "2021 International Conference on Information and Communication Technology …",
-          "authors": "NM Dang-Quang, M Yoo",
-          "description": "Many application developers are now choosing to install their Web applications on cloud data centers because of the attractiveness of cloud computing environment. Predicting future resource workload is critical since it allows cloud service providers to automatically modify resources online in order to meet service level agreements (SLA). This paper proposes a multivariate deep learning prediction model to predict future resource workload for cloud computing environment. The prediction model uses a special type of recurrent neural network (RNN) called Bidirectional long short-term memory (Bi-LSTM). This work also explains and shows the advantage by using multivariate data compared to univariate data in time series forecasting. The experiments, using real world workload dataset, show that the proposed multivariate Bi-LSTM model outperforms the univariate Bi-LSTM model in prediction accuracy."
+          "description": "Resource provisioning in cloud computing environment depends on different future resource utilization. Because the resource utilization trend may vary dynamically, we need to estimate the future resource utilization for effective resource provisioning decisions. The problem becomes more challenging since performance indicators for one resource may depend on other resources. This paper proposes a deep learning-based multivariate workload estimation with feature selection for cloud computing environment. First, we use the Pearson correlation method to select the best features as inputs for the multivariate model. Then, we propose to use the bidirectional long short-term memory (Bi-LSTM) to estimate future resource utilization. The results are conducted using a real workload dataset and show that the proposed multivariate Bi-LSTM model outperforms the multivariate LSTM model in prediction accuracy."
         },
         {
           "title": "Lightweight k3s tool for internet of things environments",
@@ -477,15 +468,6 @@
           "description": "사물 인터넷(IoT)은 스마트홈, 환경 모니터링 및 의료 등 다양한 분야에 빠르게 적용되고 있다. 그 결과 점점 더 많은 IoT 디바이스가 다양한 사용 사례에 구축되고 있다. 일반적으로 IoT(Internet of Things) 장치들은 포설된 지역의 Rasberry Pi 및 NVIDIA Jetson Nano와 같은 소형 컴퓨터로 관리된다. 최근 들어 컨테이너 기술은 컨테이너 관리 툴인 Kubernetes(K8s)와 함께 애플리케이션을 효율적으로 설치하고 관리하기 위한 가상화 기술로 부상하고 있다. 하지만 K8s는 자원이 제한된 IoT 기기에 설치되어 운영되기 어렵다. 따라서 경량 Kubernetes인 K3s는 자원이 제한된 장치용으로 특별히 설계되었다. IoT 디바이스는 네트워크 구성 및 OS(운영 체제) 설정과 같은 K3s 클러스터의 초기화 및 가입에 대한 K3s 요구 사항을 충족해야 한다. 그러나 K3s 공식 문서에서는 이러한 요구사항 구성을 지원하고 있지 않다. 본 논문에서는 요구사항 구성 및 K3s 클러스터 구현을 자동화할 수 있는 툴을 제안한다. 구현 및 평가를 통하여 제안된 툴이 빠르고 효과적으 …"
         },
         {
-          "title": "Lightweight kubeedge tool for edge computing environments",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:uc_IGeMz5qoC",
-          "citation": "VC Le, M Yoo - 한국통신학회논문지 46 (9), 1507-1514, 2021, 2021",
-          "cited_by": 4,
-          "venue": "한국통신학회논문지 46 (9), 1507-1514",
-          "authors": "VC Le, M Yoo",
-          "description": "지난 10년간 모바일 기기가 급증하면서 짧은 지연시간 내에 처리해야 하는 데이터가 급증했다. 필요한 위치에 가깝게 설계된 에지 컴퓨팅이 이러한 문제를 해결할 것으로 기대된다. 일반적으로 에지 노드는 클라우드 노드보다 적은 자원을 가지고 있다. 따라서 컨테이너 기술은 시스템에 상당한 오버헤드를 주는 가상화 기술보다 더 경쟁력 있는 솔루션으로 간주된다. 컨테이너 관리 및 조정 툴로 각광받는 Kubernetes는 에지 컴퓨팅을 완전히 지원하지 않는다. KubeEdge는 Kubernetes를 기반으로 에지 컴퓨팅에서 컨테이너 기반 애플리케이션 관리가 가능하도록 확장하였다. KubeEdge 시스템 구축에는 네트워킹 및 운영 체제에 대한 복잡한 지식이 필요하다. 본 논문에서는 KubeEdge 시스템의 구성에 필요한 절차들에 대한 복잡성을 최소화할 수 있는 경량 KubeEdge 툴 제공을 목표로 한다. 구현 및 평가를 통해 제안된 툴이 KubeEdge 시스템을 빠르고 효과적으로 구축할 수 있음을 보여주었다."
-        },
-        {
           "title": "Application for managing YAML template for Kubernetes",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:EkHepimYqZsC",
           "citation": "VC Le, M Yoo - 한국통신학회논문지 46 (11), 1950-1957, 2021, 2021",
@@ -493,6 +475,33 @@
           "venue": "한국통신학회논문지 46 (11), 1950-1957",
           "authors": "VC Le, M Yoo",
           "description": "Kubernetes(K8s)는 Cloud Native Computing Foundation(CNCF)에서 개발한 선도적인 컨테이너 오케스트레이션 툴이다. K8s는 단일 클러스터에서 애플리케이션 컨테이너 운영부터 다중 클러스터를 통한 복잡한 서비스의 자동화에 이르는 일련의 기능을 제공한다. 컨테이너형 애플리케이션은 StatefulSet, Deployment 과 같은 K8s 리소스 개체를 서술해주는 K8s YAML을 통해 K8s 클러스터 내에서 운영된다. YAML을 활용하여 서비스 구현을 가속화할 수 있지만, 이를 위해서는 K8s의 속성 및 관계에 대한 지식이 요구된다. 이전 연구들에서는 K8s에 대한 YAML 파일 자동 생성에 대한 내용을 다루었지만, YAML 파일 저장, 검색 및 수정과 같은 핵심 관리 기능은 다루어지지 않았다. 이로 인하여 여러 사용자가 여러 개의 YAML 파일을 관리하는 데 어려움이 있었다. 제안된 애플리케이션은 K8s YAML 파일의 효율적인 관리를 제공하는 것을 목표로 한다. 구현 및 평가를 통하여 제안된 애플리케이션이 효율적으로 YAML 파일을 관리할 수 있음을 보여주 …"
+        },
+        {
+          "title": "Multivariate deep learning model for workload prediction in cloud computing",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:0KyAp5RtaNEC",
+          "citation": "NM Dang-Quang, M Yoo - 2021 International Conference on Information and Communication Technology …, 2021, 2021",
+          "cited_by": 16,
+          "venue": "2021 International Conference on Information and Communication Technology …",
+          "authors": "NM Dang-Quang, M Yoo",
+          "description": "Many application developers are now choosing to install their Web applications on cloud data centers because of the attractiveness of cloud computing environment. Predicting future resource workload is critical since it allows cloud service providers to automatically modify resources online in order to meet service level agreements (SLA). This paper proposes a multivariate deep learning prediction model to predict future resource workload for cloud computing environment. The prediction model uses a special type of recurrent neural network (RNN) called Bidirectional long short-term memory (Bi-LSTM). This work also explains and shows the advantage by using multivariate data compared to univariate data in time series forecasting. The experiments, using real world workload dataset, show that the proposed multivariate Bi-LSTM model outperforms the univariate Bi-LSTM model in prediction accuracy."
+        },
+        {
+          "title": "An Automated Testing Framework for Container-Based Network Services",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:ipzZ9siozwsC",
+          "citation": "VC Le, M Yoo - 한국통신학회논문지 46 (9), 1497-1506, 2021, 2021",
+          "cited_by": 0,
+          "venue": "한국통신학회논문지 46 (9), 1497-1506",
+          "authors": "VC Le, M Yoo",
+          "description": "NFV(Network Functions Virtualization)는 운영자에게 네트워크 서비스를 위한 매우 유연하고 확장 가능한 인프라를 제공하는 네트워크 아키텍처이다. NFV 네트워크의 네트워크 기능은 공통 서버에서 구현 및 실행된다. IT기업들이 서비스 제품을 개발하기 위해 컨테이너형 기술을 사용하는 경향이 증가하고 있다. 따라서 컨테이너 기반 네트워크 서비스 테스트를 자동화하여 검증 속도를 높이고 네트워크 서비스 포설 비용을 절감할 수 있는 새로운 방법이 필요하다. 또한 제품이 포설된 환경에서 컨테이너 기반 네트워크 서비스의 기능 테스트 및 성능 평가를 위한 자동화된 테스트가 필요하다. 본 논문에서는 컨테이너 기반 네트워크 서비스에 대한 자동화 테스트 프레임워크를 제안한다. 제안된 프레임워크를 구현하고 테스트함으로써, 제안 프레임워크가 적합성, 상호운용성 및 성능 테스트를 포함하는 포괄적인 솔루션을 제공하는 것을 보였다."
+        },
+        {
+          "title": "Lightweight kubeedge tool for edge computing environments",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:uc_IGeMz5qoC",
+          "citation": "VC Le, M Yoo - 한국통신학회논문지 46 (9), 1507-1514, 2021, 2021",
+          "cited_by": 4,
+          "venue": "한국통신학회논문지 46 (9), 1507-1514",
+          "authors": "VC Le, M Yoo",
+          "description": "지난 10년간 모바일 기기가 급증하면서 짧은 지연시간 내에 처리해야 하는 데이터가 급증했다. 필요한 위치에 가깝게 설계된 에지 컴퓨팅이 이러한 문제를 해결할 것으로 기대된다. 일반적으로 에지 노드는 클라우드 노드보다 적은 자원을 가지고 있다. 따라서 컨테이너 기술은 시스템에 상당한 오버헤드를 주는 가상화 기술보다 더 경쟁력 있는 솔루션으로 간주된다. 컨테이너 관리 및 조정 툴로 각광받는 Kubernetes는 에지 컴퓨팅을 완전히 지원하지 않는다. KubeEdge는 Kubernetes를 기반으로 에지 컴퓨팅에서 컨테이너 기반 애플리케이션 관리가 가능하도록 확장하였다. KubeEdge 시스템 구축에는 네트워킹 및 운영 체제에 대한 복잡한 지식이 필요하다. 본 논문에서는 KubeEdge 시스템의 구성에 필요한 절차들에 대한 복잡성을 최소화할 수 있는 경량 KubeEdge 툴 제공을 목표로 한다. 구현 및 평가를 통해 제안된 툴이 KubeEdge 시스템을 빠르고 효과적으로 구축할 수 있음을 보여주었다."
         },
         {
           "title": "Dense-depth-net: a spatial-temporal approach on depth completion task",
@@ -504,55 +513,19 @@
           "description": "Depth completion is essential functionality in the perception system of an autonomous vehicle. With various convolution neural networks (CNN), scene geometric representation has been studied extensively under supervised learning or self-supervised learning. This paper utilizes recurrent neural networks (RNNs) to investigate temporal information from camera video sequences, which can help mitigate the mismatch between two consecutive data frames. Our paper proposed an architecture consisting of two sequence processing: the spatial exploitation stage built from a two-branches network and the temporal exploitation stage, a novel convolutional LSTM (ConvLSTM). Furthermore, we take the ability of long short-term memory (LSTM)-based RNNs to estimate a one-step depth map as an additional role of the representations of objects not only in a data frame but also in its temporal neighborhood. Moreover, the …"
         },
         {
-          "title": "A study on deep learning-based multivariate resource estimation with feature selection in cloud computing",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:vDijr-p_gm4C",
-          "citation": "NM Dang-Quang, M Yoo - 한국통신학회 학술대회논문집, 366-369, 2021, 2021",
-          "cited_by": 2,
-          "venue": "한국통신학회 학술대회논문집, 366-369",
+          "title": "Deep learning-based autoscaling using bidirectional long short-term memory for kubernetes",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:VLnqNzywnoUC",
+          "citation": "NM Dang-Quang, M Yoo - Applied Sciences 11 (9), 3835, 2021, 2021",
+          "cited_by": 97,
+          "venue": "Applied Sciences 11 (9), 3835",
           "authors": "NM Dang-Quang, M Yoo",
-          "description": "Resource provisioning in cloud computing environment depends on different future resource utilization. Because the resource utilization trend may vary dynamically, we need to estimate the future resource utilization for effective resource provisioning decisions. The problem becomes more challenging since performance indicators for one resource may depend on other resources. This paper proposes a deep learning-based multivariate workload estimation with feature selection for cloud computing environment. First, we use the Pearson correlation method to select the best features as inputs for the multivariate model. Then, we propose to use the bidirectional long short-term memory (Bi-LSTM) to estimate future resource utilization. The results are conducted using a real workload dataset and show that the proposed multivariate Bi-LSTM model outperforms the multivariate LSTM model in prediction accuracy."
-        },
-        {
-          "title": "An Automated Testing Framework for Container-Based Network Services",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:ipzZ9siozwsC",
-          "citation": "VC Le, M Yoo - 한국통신학회논문지 46 (9), 1497-1506, 2021, 2021",
-          "cited_by": 0,
-          "venue": "한국통신학회논문지 46 (9), 1497-1506",
-          "authors": "VC Le, M Yoo",
-          "description": "NFV(Network Functions Virtualization)는 운영자에게 네트워크 서비스를 위한 매우 유연하고 확장 가능한 인프라를 제공하는 네트워크 아키텍처이다. NFV 네트워크의 네트워크 기능은 공통 서버에서 구현 및 실행된다. IT기업들이 서비스 제품을 개발하기 위해 컨테이너형 기술을 사용하는 경향이 증가하고 있다. 따라서 컨테이너 기반 네트워크 서비스 테스트를 자동화하여 검증 속도를 높이고 네트워크 서비스 포설 비용을 절감할 수 있는 새로운 방법이 필요하다. 또한 제품이 포설된 환경에서 컨테이너 기반 네트워크 서비스의 기능 테스트 및 성능 평가를 위한 자동화된 테스트가 필요하다. 본 논문에서는 컨테이너 기반 네트워크 서비스에 대한 자동화 테스트 프레임워크를 제안한다. 제안된 프레임워크를 구현하고 테스트함으로써, 제안 프레임워크가 적합성, 상호운용성 및 성능 테스트를 포함하는 포괄적인 솔루션을 제공하는 것을 보였다."
+          "description": "Presently, the cloud computing environment attracts many application developers to deploy their web applications on cloud data centers. Kubernetes, a well-known container orchestration for deploying web applications on cloud systems, offers an automatic scaling feature to meet clients’ ever-changing demands with the reactive approach. This paper proposes a system architecture based on Kubernetes with a proactive custom autoscaler using a deep neural network model to handle the workload during run time dynamically. The proposed system architecture is designed based on the Monitor–Analyze–Plan–Execute (MAPE) loop. The main contribution of this paper is the proactive custom autoscaler, which focuses on the analysis and planning phases. In analysis phase, Bidirectional Long Short-term Memory (Bi-LSTM) is applied to predict the number of HTTP workloads in the future. In the planning phase, a cooling-down time period is implemented to mitigate the oscillation problem. In addition, a resource removal strategy is proposed to remove a part of the resources when the workload decreases, so that the autoscaler can handle it faster when the burst of workload happens. Through experiments with two different realistic workloads, the Bi-LSTM model achieves better accuracy not only than the Long Short-Term Memory model but also than the state-of-the-art statistical auto-regression integrated moving average model in terms of short- and long-term forecasting. Moreover, it offers 530 to 600 times faster prediction speed than ARIMA models with different workloads. Furthermore, as compared to the LSTM model, the Bi-LSTM model …"
         }
       ]
     },
     {
       "year": 2020,
       "entries": [
-        {
-          "title": "Nighttime vehicle detection and tracking with occlusion handling by pairing headlights and taillights",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:7T2F9Uy0os0C",
-          "citation": "TA Pham, M Yoo - Applied Sciences 10 (11), 3986, 2020, 2020",
-          "cited_by": 29,
-          "venue": "Applied Sciences 10 (11), 3986",
-          "authors": "TA Pham, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "The necessity of LED to ambient light ratio optimization for vehicular optical camera communication",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:uLbwQdceFCQC",
-          "citation": "TH Do, M Yoo - Sensors 20 (1), 292, 2020, 2020",
-          "cited_by": 7,
-          "venue": "Sensors 20 (1), 292",
-          "authors": "TH Do, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "A taillight matching and pairing algorithm for stereo-vision-based nighttime vehicle-to-vehicle positioning",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:tzM49s52ZIMC",
-          "citation": "TH Huynh, M Yoo - Applied Sciences 10 (19), 6800, 2020, 2020",
-          "cited_by": 5,
-          "venue": "Applied Sciences 10 (19), 6800",
-          "authors": "TH Huynh, M Yoo",
-          "description": "Featured Application                        This paper proposes taillight detection, stereo taillight matching, and taillight pairing methods for the stereo-vision-based nighttime vehicle-to-vehicle positioning process. This process can be used in advanced driver-assistance systems and autonomous vehicles.                                        Abstract           The stereo vision system has several potential benefits for delivering advanced autonomous vehicles compared to other existing technologies, such as vehicle-to-vehicle (V2V) positioning. This paper explores a stereo-vision-based nighttime V2V positioning process by detecting vehicle taillights. To address the crucial problems when applying this process to urban traffic, we propose a three-fold contribution as follows. The first contribution is a detection method that aims to label and determine the pixel coordinates of every taillight region from the images. Second, a stereo matching method derived from a gradient boosted tree is proposed to determine which taillight in the left image a taillight in the right image corresponds to. Third, we offer a neural-network-based method to pair every two taillights that belong to the same vehicle. The experiment on the four-lane traffic road was conducted, and the results were used to quantitatively evaluate the performance of each proposed method in real situations."
-        },
         {
           "title": "A web application load prediction model using recurrent neural network in cloud",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:z_wVstp3MssC",
@@ -572,6 +545,15 @@
           "description": "Network functions virtualization (NFV) is a new manner to virtualize entire classes of network node functions to create network services. The network functions of an NFV network do not require any dedicated hardware. NFV brings advantages to deploy network service. They only need a general server to be implemented and executed. Moreover, NFV has an important concept that is the service functions chain (SFC). It includes more than one network functions that work together to form a network service. The SFCs need to be evaluated performance and functional to ensure reliability and dependability. Although the previous work they proposed an agent-based mechanism for testing SFC, they only test the SFC on Layer 4. In the paper, we will implement the mechanism on Layer 7 to evaluate the reliability and dependability of the previous works."
         },
         {
+          "title": "A taillight matching and pairing algorithm for stereo-vision-based nighttime vehicle-to-vehicle positioning",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:tzM49s52ZIMC",
+          "citation": "TH Huynh, M Yoo - Applied Sciences 10 (19), 6800, 2020, 2020",
+          "cited_by": 5,
+          "venue": "Applied Sciences 10 (19), 6800",
+          "authors": "TH Huynh, M Yoo",
+          "description": "Featured Application                        This paper proposes taillight detection, stereo taillight matching, and taillight pairing methods for the stereo-vision-based nighttime vehicle-to-vehicle positioning process. This process can be used in advanced driver-assistance systems and autonomous vehicles.                                        Abstract           The stereo vision system has several potential benefits for delivering advanced autonomous vehicles compared to other existing technologies, such as vehicle-to-vehicle (V2V) positioning. This paper explores a stereo-vision-based nighttime V2V positioning process by detecting vehicle taillights. To address the crucial problems when applying this process to urban traffic, we propose a three-fold contribution as follows. The first contribution is a detection method that aims to label and determine the pixel coordinates of every taillight region from the images. Second, a stereo matching method derived from a gradient boosted tree is proposed to determine which taillight in the left image a taillight in the right image corresponds to. Third, we offer a neural-network-based method to pair every two taillights that belong to the same vehicle. The experiment on the four-lane traffic road was conducted, and the results were used to quantitatively evaluate the performance of each proposed method in real situations."
+        },
+        {
           "title": "Nighttime LED Taillight Detection Method with Optical Camera Communication System",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:2KloaMYe4IUC",
           "citation": "TH Huynh, M Yoo - 한국통신학회논문지 45 (9), 1591-1596, 2020, 2020",
@@ -587,7 +569,16 @@
           "cited_by": 0,
           "venue": "한국통신학회 학술대회논문집, 230-232",
           "authors": "C Le, M Yoo",
-          "description": ""
+          "description": "Network functions virtualization (NFV) is a network architecture concept that uses the technologies of IT virtualization to virtualize entire classes of network node functions into building blocks. The network functions of an NFV network do not require any dedicated hardware. They only need a general server to be implemented and executed. Moreover, NFV has an important concept that is the service functions chain (SFC). It includes more than one network functions that work together to form a network service. NFV brings advantages to deploy network service. However, it also has challenges that need to be considered, especially fault recovery. Almost current solutions are passive self-healing. Although there are some efforts toward active self-healing, a comprehensive solution still has not been proposed. The proposed mechanism is based on testing to build rule-based solutions for self-healing in the deploying …"
+        },
+        {
+          "title": "Nighttime vehicle detection and tracking with occlusion handling by pairing headlights and taillights",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:7T2F9Uy0os0C",
+          "citation": "TA Pham, M Yoo - Applied Sciences 10 (11), 3986, 2020, 2020",
+          "cited_by": 29,
+          "venue": "Applied Sciences 10 (11), 3986",
+          "authors": "TA Pham, M Yoo",
+          "description": "In recent years, vision-based vehicle detection has received considerable attention in the literature. Depending on the ambient illuminance, vehicle detection methods are classified as daytime and nighttime detection methods. In this paper, we propose a nighttime vehicle detection and tracking method with occlusion handling based on vehicle lights. First, bright blobs that may be vehicle lights are segmented in the captured image. Then, a machine learning-based method is proposed to classify whether the bright blobs are headlights, taillights, or other illuminant objects. Subsequently, the detected vehicle lights are tracked to further facilitate the determination of the vehicle position. As one vehicle is indicated by one or two light pairs, a light pairing process using spatiotemporal features is applied to pair vehicle lights. Finally, vehicle tracking with occlusion handling is applied to refine incorrect detections under various traffic situations. Experiments on two-lane and four-lane urban roads are conducted, and a quantitative evaluation of the results shows the effectiveness of the proposed method."
         },
         {
           "title": "Performance Evaluation of Optical Camera Communication System Using Two-Dimensional Coding",
@@ -624,6 +615,15 @@
           "venue": "US Patent 10,637,886",
           "authors": "MS Yoo, TH Nguyen, JS Choi",
           "description": ""
+        },
+        {
+          "title": "The necessity of LED to ambient light ratio optimization for vehicular optical camera communication",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:uLbwQdceFCQC",
+          "citation": "TH Do, M Yoo - Sensors 20 (1), 292, 2020, 2020",
+          "cited_by": 7,
+          "venue": "Sensors 20 (1), 292",
+          "authors": "TH Do, M Yoo",
+          "description": ""
         }
       ]
     },
@@ -631,30 +631,48 @@
       "year": 2019,
       "entries": [
         {
-          "title": "Visible light communication-based vehicle-to-vehicle tracking using CMOS camera",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:cFHS6HbyZ2cC",
-          "citation": "TH Do, M Yoo - IEEE Access 7, 7218-7227, 2019, 2019",
-          "cited_by": 37,
-          "venue": "IEEE Access 7, 7218-7227",
+          "title": "A Framework for Realistic Simulations of Optical Camera Communication Systems",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:_Ybze24A_UAC",
+          "citation": "TH Do, M Yoo - 한국통신학회논문지 44 (12), 2309-2314, 2019, 2019",
+          "cited_by": 0,
+          "venue": "한국통신학회논문지 44 (12), 2309-2314",
           "authors": "TH Do, M Yoo",
           "description": ""
         },
         {
-          "title": "A multi-feature LED bit detection algorithm in vehicular optical camera communication",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:eflP2zaiRacC",
-          "citation": "TH Do, M Yoo - IEEE access 7, 95797-95811, 2019, 2019",
-          "cited_by": 19,
-          "venue": "IEEE access 7, 95797-95811",
+          "title": "A simple LED panel dection algoritum for Optical Camera Communication systems",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:JQOojiI6XY0C",
+          "citation": "TH Do, M Yoo - 2019 International Conference on Information and Communication Technology …, 2019, 2019",
+          "cited_by": 3,
+          "venue": "2019 International Conference on Information and Communication Technology …",
           "authors": "TH Do, M Yoo",
           "description": ""
         },
         {
-          "title": "Multiple exposure coding for short and long dual transmission in vehicle optical camera communication",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:l7t_Zn2s7bgC",
-          "citation": "TH Do, M Yoo - IEEE Access 7, 35148-35161, 2019, 2019",
-          "cited_by": 19,
-          "venue": "IEEE Access 7, 35148-35161",
-          "authors": "TH Do, M Yoo",
+          "title": "A Self-Healing Mechanism for NFV By Leveraging Resource Information Indexing Technique",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:UHK10RUVsp4C",
+          "citation": "T Nguyen, C Le, M Yoo - 2019 International Conference on Information and Communication Technology …, 2019, 2019",
+          "cited_by": 1,
+          "venue": "2019 International Conference on Information and Communication Technology …",
+          "authors": "T Nguyen, C Le, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "An agent-based mechanism for testing sfc",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:PR6Y55bgFSsC",
+          "citation": "T Nguyen, M Yoo - 한국통신학회논문지 44 (10), 1949-1955, 2019, 2019",
+          "cited_by": 2,
+          "venue": "한국통신학회논문지 44 (10), 1949-1955",
+          "authors": "T Nguyen, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "A VNF Placement Optimization Framework for Network Function Virtualization",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:1yQoGdGgb4wC",
+          "citation": "TH Nguyen, M Yoo - 한국통신학회논문지 44 (10), 1956-1960, 2019, 2019",
+          "cited_by": 0,
+          "venue": "한국통신학회논문지 44 (10), 1956-1960",
+          "authors": "TH Nguyen, M Yoo",
           "description": ""
         },
         {
@@ -667,11 +685,11 @@
           "description": ""
         },
         {
-          "title": "A simple LED panel dection algoritum for Optical Camera Communication systems",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:JQOojiI6XY0C",
-          "citation": "TH Do, M Yoo - 2019 International Conference on Information and Communication Technology …, 2019, 2019",
-          "cited_by": 3,
-          "venue": "2019 International Conference on Information and Communication Technology …",
+          "title": "A multi-feature LED bit detection algorithm in vehicular optical camera communication",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:eflP2zaiRacC",
+          "citation": "TH Do, M Yoo - IEEE access 7, 95797-95811, 2019, 2019",
+          "cited_by": 19,
+          "venue": "IEEE access 7, 95797-95811",
           "authors": "TH Do, M Yoo",
           "description": ""
         },
@@ -685,12 +703,21 @@
           "description": ""
         },
         {
-          "title": "An agent-based mechanism for testing sfc",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:PR6Y55bgFSsC",
-          "citation": "T Nguyen, M Yoo - 한국통신학회논문지 44 (10), 1949-1955, 2019, 2019",
-          "cited_by": 2,
-          "venue": "한국통신학회논문지 44 (10), 1949-1955",
+          "title": "An Implementation of The Interoperability Testing Service for Service Function Chains",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:hkOj_22Ku90C",
+          "citation": "T Nguyen, M Yoo - 한국통신학회 학술대회논문집, 572-573, 2019, 2019",
+          "cited_by": 0,
+          "venue": "한국통신학회 학술대회논문집, 572-573",
           "authors": "T Nguyen, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Multiple exposure coding for short and long dual transmission in vehicle optical camera communication",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:l7t_Zn2s7bgC",
+          "citation": "TH Do, M Yoo - IEEE Access 7, 35148-35161, 2019, 2019",
+          "cited_by": 19,
+          "venue": "IEEE Access 7, 35148-35161",
+          "authors": "TH Do, M Yoo",
           "description": ""
         },
         {
@@ -703,48 +730,21 @@
           "description": ""
         },
         {
-          "title": "A Self-Healing Mechanism for NFV By Leveraging Resource Information Indexing Technique",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:UHK10RUVsp4C",
-          "citation": "T Nguyen, C Le, M Yoo - 2019 International Conference on Information and Communication Technology …, 2019, 2019",
-          "cited_by": 1,
-          "venue": "2019 International Conference on Information and Communication Technology …",
-          "authors": "T Nguyen, C Le, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "A Framework for Realistic Simulations of Optical Camera Communication Systems",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:_Ybze24A_UAC",
-          "citation": "TH Do, M Yoo - 한국통신학회논문지 44 (12), 2309-2314, 2019, 2019",
-          "cited_by": 0,
-          "venue": "한국통신학회논문지 44 (12), 2309-2314",
-          "authors": "TH Do, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "A VNF Placement Optimization Framework for Network Function Virtualization",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:1yQoGdGgb4wC",
-          "citation": "TH Nguyen, M Yoo - 한국통신학회논문지 44 (10), 1956-1960, 2019, 2019",
-          "cited_by": 0,
-          "venue": "한국통신학회논문지 44 (10), 1956-1960",
-          "authors": "TH Nguyen, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "An Implementation of The Interoperability Testing Service for Service Function Chains",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:hkOj_22Ku90C",
-          "citation": "T Nguyen, M Yoo - 한국통신학회 학술대회논문집, 572-573, 2019, 2019",
-          "cited_by": 0,
-          "venue": "한국통신학회 학술대회논문집, 572-573",
-          "authors": "T Nguyen, M Yoo",
-          "description": ""
-        },
-        {
           "title": "A YAML-Based Profiler for Designing SFC Tests",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:W5xh706n7nkC",
           "citation": "유명식 - 한국통신학회논문지 44 (12), 2303-2308, 2019, 2019",
           "cited_by": 0,
           "venue": "한국통신학회논문지 44 (12), 2303-2308",
           "authors": "유명식",
+          "description": ""
+        },
+        {
+          "title": "Visible light communication-based vehicle-to-vehicle tracking using CMOS camera",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:cFHS6HbyZ2cC",
+          "citation": "TH Do, M Yoo - IEEE Access 7, 7218-7227, 2019, 2019",
+          "cited_by": 37,
+          "venue": "IEEE Access 7, 7218-7227",
+          "authors": "TH Do, M Yoo",
           "description": ""
         },
         {
@@ -762,60 +762,6 @@
       "year": 2018,
       "entries": [
         {
-          "title": "Vehicle-to-vehicle distance estimation using a low-resolution camera based on visible light communications",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:WA5NYHcadZ8C",
-          "citation": "VTB Tram, M Yoo - IEEE Access 6, 4521-4527, 2018, 2018",
-          "cited_by": 83,
-          "venue": "IEEE Access 6, 4521-4527",
-          "authors": "VTB Tram, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "SOFTWARE DEFINED NETWORK CAPABLE OF DETECTING DDoS ATTACKS USING ARTIFICIAL INTELLIGENCE AND CONTROLLER INCLUDED IN THE SAME",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:KxtntwgDAa4C",
-          "citation": "MS Yoo, TH Nguyen, JS Choi - US Patent App. 15/692,320, 2018, 2018",
-          "cited_by": 45,
-          "venue": "US Patent App. 15/692,320",
-          "authors": "MS Yoo, TH Nguyen, JS Choi",
-          "description": ""
-        },
-        {
-          "title": "Visible light communication based vehicle positioning using LED street light and rolling shutter CMOS sensors",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:tkaPQYYpVKoC",
-          "citation": "TH Do, M Yoo - Optics Communications 407, 112-126, 2018, 2018",
-          "cited_by": 37,
-          "venue": "Optics Communications 407, 112-126",
-          "authors": "TH Do, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Analysis of deployment approaches for virtual customer premises equipment",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:Zph67rFs4hoC",
-          "citation": "TH Nguyen, T Nguyen, M Yoo - 2018 International Conference on Information Networking (ICOIN), 289-291, 2018, 2018",
-          "cited_by": 17,
-          "venue": "2018 International Conference on Information Networking (ICOIN), 289-291",
-          "authors": "TH Nguyen, T Nguyen, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Interpixel interference mitigation in visible light communication using image sensor",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:Wp0gIr-vW9MC",
-          "citation": "D Vuong, M Yoo - IEEE Access 6, 45543-45551, 2018, 2018",
-          "cited_by": 13,
-          "venue": "IEEE Access 6, 45543-45551",
-          "authors": "D Vuong, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "A vnf descriptor generator for tacker-based nfv management and orchestration",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:f2IySw72cVMC",
-          "citation": "TH Nguyen, M Yoo - 2018 International Conference on Information and Communication Technology …, 2018, 2018",
-          "cited_by": 12,
-          "venue": "2018 International Conference on Information and Communication Technology …",
-          "authors": "TH Nguyen, M Yoo",
-          "description": ""
-        },
-        {
           "title": "Rolling shutter compensation for vehicle to vehicle positioning using CMOS sensor camera",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:CHSYGLWDkRkC",
           "citation": "TH Do, M Yoo - 2018 International Conference on Information and Communication Technology …, 2018, 2018",
@@ -825,12 +771,12 @@
           "description": ""
         },
         {
-          "title": "Interpixel interference mitigation using differential coding in vehicular visible light communication based image sensor",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:VL0QpB8kHFEC",
-          "citation": "D Vuong, J Lee, SK Hong, WY Shin, M Yoo - 2018 International Conference on Information Networking (ICOIN), 846-847, 2018, 2018",
-          "cited_by": 3,
-          "venue": "2018 International Conference on Information Networking (ICOIN), 846-847",
-          "authors": "D Vuong, J Lee, SK Hong, WY Shin, M Yoo",
+          "title": "A vnf descriptor generator for tacker-based nfv management and orchestration",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:f2IySw72cVMC",
+          "citation": "TH Nguyen, M Yoo - 2018 International Conference on Information and Communication Technology …, 2018, 2018",
+          "cited_by": 12,
+          "venue": "2018 International Conference on Information and Communication Technology …",
+          "authors": "TH Nguyen, M Yoo",
           "description": ""
         },
         {
@@ -870,6 +816,15 @@
           "description": ""
         },
         {
+          "title": "Interpixel interference mitigation in visible light communication using image sensor",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:Wp0gIr-vW9MC",
+          "citation": "D Vuong, M Yoo - IEEE Access 6, 45543-45551, 2018, 2018",
+          "cited_by": 13,
+          "venue": "IEEE Access 6, 45543-45551",
+          "authors": "D Vuong, M Yoo",
+          "description": ""
+        },
+        {
           "title": "A Comprehensive NFV vCPE System with VyOS-based VNF",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:ye4kPcJQO24C",
           "citation": "TH Nguyen, M Yoo - 한국통신학회 학술대회논문집, 415-416, 2018, 2018",
@@ -888,12 +843,57 @@
           "description": ""
         },
         {
+          "title": "SOFTWARE DEFINED NETWORK CAPABLE OF DETECTING DDoS ATTACKS USING ARTIFICIAL INTELLIGENCE AND CONTROLLER INCLUDED IN THE SAME",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:KxtntwgDAa4C",
+          "citation": "MS Yoo, TH Nguyen, JS Choi - US Patent App. 15/692,320, 2018, 2018",
+          "cited_by": 45,
+          "venue": "US Patent App. 15/692,320",
+          "authors": "MS Yoo, TH Nguyen, JS Choi",
+          "description": ""
+        },
+        {
           "title": "Method and server for providing a social network service",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:tOudhMTPpwUC",
           "citation": "MS Yoo, W Quan - US Patent 9,875,361, 2018, 2018",
           "cited_by": 0,
           "venue": "US Patent 9,875,361",
           "authors": "MS Yoo, W Quan",
+          "description": ""
+        },
+        {
+          "title": "Visible light communication based vehicle positioning using LED street light and rolling shutter CMOS sensors",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:tkaPQYYpVKoC",
+          "citation": "TH Do, M Yoo - Optics Communications 407, 112-126, 2018, 2018",
+          "cited_by": 37,
+          "venue": "Optics Communications 407, 112-126",
+          "authors": "TH Do, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Vehicle-to-vehicle distance estimation using a low-resolution camera based on visible light communications",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:WA5NYHcadZ8C",
+          "citation": "VTB Tram, M Yoo - IEEE Access 6, 4521-4527, 2018, 2018",
+          "cited_by": 83,
+          "venue": "IEEE Access 6, 4521-4527",
+          "authors": "VTB Tram, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Interpixel interference mitigation using differential coding in vehicular visible light communication based image sensor",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:VL0QpB8kHFEC",
+          "citation": "D Vuong, J Lee, SK Hong, WY Shin, M Yoo - 2018 International Conference on Information Networking (ICOIN), 846-847, 2018, 2018",
+          "cited_by": 3,
+          "venue": "2018 International Conference on Information Networking (ICOIN), 846-847",
+          "authors": "D Vuong, J Lee, SK Hong, WY Shin, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Analysis of deployment approaches for virtual customer premises equipment",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:Zph67rFs4hoC",
+          "citation": "TH Nguyen, T Nguyen, M Yoo - 2018 International Conference on Information Networking (ICOIN), 289-291, 2018, 2018",
+          "cited_by": 17,
+          "venue": "2018 International Conference on Information Networking (ICOIN), 289-291",
+          "authors": "TH Nguyen, T Nguyen, M Yoo",
           "description": ""
         }
       ]
@@ -902,12 +902,57 @@
       "year": 2017,
       "entries": [
         {
-          "title": "Analysis of link discovery service attacks in SDN controller",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:eMMeJKvmdy0C",
-          "citation": "TH Nguyen, M Yoo - 2017 International Conference on Information Networking (ICOIN), 259-261, 2017, 2017",
-          "cited_by": 84,
-          "venue": "2017 International Conference on Information Networking (ICOIN), 259-261",
+          "title": "Handover procedure and algorithm in vehicle to infrastructure visible light communication",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:MXK_kJrjxJIC",
+          "citation": "QH Dang, M Yoo - IEEE Access 5, 26466-26475, 2017, 2017",
+          "cited_by": 32,
+          "venue": "IEEE Access 5, 26466-26475",
+          "authors": "QH Dang, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "A behavior-based mobile malware detection model in software-defined networking",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:D_sINldO8mEC",
+          "citation": "TH Nguyen, M Yoo - 2017 International Conference on Information Science and Communications …, 2017, 2017",
+          "cited_by": 6,
+          "venue": "2017 International Conference on Information Science and Communications …",
           "authors": "TH Nguyen, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "A hybrid prevention method for eavesdropping attack by link spoofing in software-defined Internet of Things controllers",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:tS2w5q8j5-wC",
+          "citation": "TH Nguyen, M Yoo - International Journal of Distributed Sensor Networks 13 (11), 1550147717739157, 2017, 2017",
+          "cited_by": 19,
+          "venue": "International Journal of Distributed Sensor Networks 13 (11), 1550147717739157",
+          "authors": "TH Nguyen, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Vehicle to vehicle distance estimation using camera based visible light communications",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:70eg2SAEIzsC",
+          "citation": "VTB Tram, M Yoo - 2017 International Conference on Information and Communication Technology …, 2017, 2017",
+          "cited_by": 7,
+          "venue": "2017 International Conference on Information and Communication Technology …",
+          "authors": "VTB Tram, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Analysis of attacks on device manager in software-defined Internet of Things",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:8k81kl-MbHgC",
+          "citation": "TH Nguyen, M Yoo - International Journal of Distributed Sensor Networks 13 (8), 1550147717728681, 2017, 2017",
+          "cited_by": 4,
+          "venue": "International Journal of Distributed Sensor Networks 13 (8), 1550147717728681",
+          "authors": "TH Nguyen, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Overlay coding in vehicle visible light communication using multiple exposures",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:qUcmZB5y_30C",
+          "citation": "TH Do, M Yoo - 2017 Ninth International Conference on Ubiquitous and Future Networks (ICUFN …, 2017, 2017",
+          "cited_by": 0,
+          "venue": "2017 Ninth International Conference on Ubiquitous and Future Networks (ICUFN …",
+          "authors": "TH Do, M Yoo",
           "description": ""
         },
         {
@@ -920,15 +965,6 @@
           "description": ""
         },
         {
-          "title": "Handover procedure and algorithm in vehicle to infrastructure visible light communication",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:MXK_kJrjxJIC",
-          "citation": "QH Dang, M Yoo - IEEE Access 5, 26466-26475, 2017, 2017",
-          "cited_by": 32,
-          "venue": "IEEE Access 5, 26466-26475",
-          "authors": "QH Dang, M Yoo",
-          "description": ""
-        },
-        {
           "title": "A probability-based algorithm using image sensors to track the LED in a vehicle visible light communication system",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:35N4QoGY0k4C",
           "citation": "P Huynh, TH Do, M Yoo - Sensors 17 (2), 347, 2017, 2017",
@@ -938,11 +974,11 @@
           "description": ""
         },
         {
-          "title": "A hybrid prevention method for eavesdropping attack by link spoofing in software-defined Internet of Things controllers",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:tS2w5q8j5-wC",
-          "citation": "TH Nguyen, M Yoo - International Journal of Distributed Sensor Networks 13 (11), 1550147717739157, 2017, 2017",
-          "cited_by": 19,
-          "venue": "International Journal of Distributed Sensor Networks 13 (11), 1550147717739157",
+          "title": "Analysis of link discovery service attacks in SDN controller",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:eMMeJKvmdy0C",
+          "citation": "TH Nguyen, M Yoo - 2017 International Conference on Information Networking (ICOIN), 259-261, 2017, 2017",
+          "cited_by": 84,
+          "venue": "2017 International Conference on Information Networking (ICOIN), 259-261",
           "authors": "TH Nguyen, M Yoo",
           "description": ""
         },
@@ -956,47 +992,11 @@
           "description": ""
         },
         {
-          "title": "Vehicle to vehicle distance estimation using camera based visible light communications",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:70eg2SAEIzsC",
-          "citation": "VTB Tram, M Yoo - 2017 International Conference on Information and Communication Technology …, 2017, 2017",
-          "cited_by": 7,
-          "venue": "2017 International Conference on Information and Communication Technology …",
-          "authors": "VTB Tram, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "A behavior-based mobile malware detection model in software-defined networking",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:D_sINldO8mEC",
-          "citation": "TH Nguyen, M Yoo - 2017 International Conference on Information Science and Communications …, 2017, 2017",
-          "cited_by": 6,
-          "venue": "2017 International Conference on Information Science and Communications …",
-          "authors": "TH Nguyen, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Analysis of attacks on device manager in software-defined Internet of Things",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:8k81kl-MbHgC",
-          "citation": "TH Nguyen, M Yoo - International Journal of Distributed Sensor Networks 13 (8), 1550147717728681, 2017, 2017",
-          "cited_by": 4,
-          "venue": "International Journal of Distributed Sensor Networks 13 (8), 1550147717728681",
-          "authors": "TH Nguyen, M Yoo",
-          "description": ""
-        },
-        {
           "title": "Two-Dimensional Coding for Optical Camera Communication using CMOS Sensors",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:7PzlFSSx8tAC",
           "citation": "TH Do, M Yoo - International Conference on Information and Communications, 2017, 2017",
           "cited_by": 2,
           "venue": "International Conference on Information and Communications",
-          "authors": "TH Do, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Overlay coding in vehicle visible light communication using multiple exposures",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:qUcmZB5y_30C",
-          "citation": "TH Do, M Yoo - 2017 Ninth International Conference on Ubiquitous and Future Networks (ICUFN …, 2017, 2017",
-          "cited_by": 0,
-          "venue": "2017 Ninth International Conference on Ubiquitous and Future Networks (ICUFN …",
           "authors": "TH Do, M Yoo",
           "description": ""
         }
@@ -1006,11 +1006,29 @@
       "year": 2016,
       "entries": [
         {
-          "title": "An in-depth survey of visible light communication based positioning systems",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:k_IJM867U9cC",
-          "citation": "TH Do, M Yoo - Sensors 16 (5), 678, 2016, 2016",
-          "cited_by": 413,
-          "venue": "Sensors 16 (5), 678",
+          "title": "Attacks on host tracker in SDN controller: Investigation and prevention",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:mB3voiENLucC",
+          "citation": "TH Nguyen, M Yoo - 2016 International Conference on Information and Communication Technology …, 2016, 2016",
+          "cited_by": 20,
+          "venue": "2016 International Conference on Information and Communication Technology …",
+          "authors": "TH Nguyen, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Method and apparatus for propagating a message in a social network",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:L8Ckcad2t8MC",
+          "citation": "MS Yoo, DL Nguyen, W Quan - US Patent 9,444,778, 2016, 2016",
+          "cited_by": 1,
+          "venue": "US Patent 9,444,778",
+          "authors": "MS Yoo, DL Nguyen, W Quan",
+          "description": ""
+        },
+        {
+          "title": "Visible light communication based vehicle positioning using a rolling shutter CMOS sensor",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:1qzjygNMrQYC",
+          "citation": "TH Do, M Yoo - 2016 Eighth International Conference on Ubiquitous and Future Networks …, 2016, 2016",
+          "cited_by": 13,
+          "venue": "2016 Eighth International Conference on Ubiquitous and Future Networks …",
           "authors": "TH Do, M Yoo",
           "description": ""
         },
@@ -1024,29 +1042,29 @@
           "description": ""
         },
         {
+          "title": "An in-depth survey of visible light communication based positioning systems",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:k_IJM867U9cC",
+          "citation": "TH Do, M Yoo - Sensors 16 (5), 678, 2016, 2016",
+          "cited_by": 413,
+          "venue": "Sensors 16 (5), 678",
+          "authors": "TH Do, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Method and gateway for extending EtherCAT network",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:roLk4NBRz8UC",
+          "citation": "MS Yoo, SY Lee, WH Lee - US Patent 9,313,050, 2016, 2016",
+          "cited_by": 1,
+          "venue": "US Patent 9,313,050",
+          "authors": "MS Yoo, SY Lee, WH Lee",
+          "description": ""
+        },
+        {
           "title": "Performance analysis of visible light communication using CMOS sensors",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:-f6ydRqryjwC",
           "citation": "TH Do, M Yoo - Sensors 16 (3), 309, 2016, 2016",
           "cited_by": 89,
           "venue": "Sensors 16 (3), 309",
-          "authors": "TH Do, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Attacks on host tracker in SDN controller: Investigation and prevention",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:mB3voiENLucC",
-          "citation": "TH Nguyen, M Yoo - 2016 International Conference on Information and Communication Technology …, 2016, 2016",
-          "cited_by": 20,
-          "venue": "2016 International Conference on Information and Communication Technology …",
-          "authors": "TH Nguyen, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Visible light communication based vehicle positioning using a rolling shutter CMOS sensor",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:1qzjygNMrQYC",
-          "citation": "TH Do, M Yoo - 2016 Eighth International Conference on Ubiquitous and Future Networks …, 2016, 2016",
-          "cited_by": 13,
-          "venue": "2016 Eighth International Conference on Ubiquitous and Future Networks …",
           "authors": "TH Do, M Yoo",
           "description": ""
         },
@@ -1057,24 +1075,6 @@
           "cited_by": 7,
           "venue": "Wireless Personal Communications 86 (4), 1751-1763",
           "authors": "TH Do, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Method and apparatus for propagating a message in a social network",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:L8Ckcad2t8MC",
-          "citation": "MS Yoo, DL Nguyen, W Quan - US Patent 9,444,778, 2016, 2016",
-          "cited_by": 1,
-          "venue": "US Patent 9,444,778",
-          "authors": "MS Yoo, DL Nguyen, W Quan",
-          "description": ""
-        },
-        {
-          "title": "Method and gateway for extending EtherCAT network",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:roLk4NBRz8UC",
-          "citation": "MS Yoo, SY Lee, WH Lee - US Patent 9,313,050, 2016, 2016",
-          "cited_by": 1,
-          "venue": "US Patent 9,313,050",
-          "authors": "MS Yoo, SY Lee, WH Lee",
           "description": ""
         },
         {
@@ -1092,12 +1092,12 @@
       "year": 2015,
       "entries": [
         {
-          "title": "Potentialities and challenges of VLC based outdoor positioning",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:YOwf2qJgpHMC",
-          "citation": "TH Do, M Yoo - 2015 International Conference on Information Networking (ICOIN), 474-477, 2015, 2015",
-          "cited_by": 45,
-          "venue": "2015 International Conference on Information Networking (ICOIN), 474-477",
-          "authors": "TH Do, M Yoo",
+          "title": "Mobile terminal capable of localization, localization server and method for localizing the mobile terminal using the localization server",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:AXPGKjj_ei8C",
+          "citation": "M Yoo, J Hwang - US Patent 9,184,837, 2015, 2015",
+          "cited_by": 2,
+          "venue": "US Patent 9,184,837",
+          "authors": "M Yoo, J Hwang",
           "description": ""
         },
         {
@@ -1110,12 +1110,30 @@
           "description": ""
         },
         {
+          "title": "Recent advances of ICT convergence on wsn applications",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:QIV2ME_5wuYC",
+          "citation": "M Yoo, F Wu, C Qiao - International Journal of Distributed Sensor Networks 11 (8), 247371, 2015, 2015",
+          "cited_by": 5,
+          "venue": "International Journal of Distributed Sensor Networks 11 (8), 247371",
+          "authors": "M Yoo, F Wu, C Qiao",
+          "description": ""
+        },
+        {
           "title": "Packet loss compensation for control systems over industrial wireless sensor networks",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:aqlVkmm33-oC",
           "citation": "VAQ Nguyen, M Yoo - International Journal of Distributed Sensor Networks 11 (8), 256757, 2015, 2015",
           "cited_by": 13,
           "venue": "International Journal of Distributed Sensor Networks 11 (8), 256757",
           "authors": "VAQ Nguyen, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Method and apparatus for controlling access in a social network service",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:qxL8FJ1GzNcC",
+          "citation": "MS Yoo, W Quan - US Patent 9,117,089, 2015, 2015",
+          "cited_by": 6,
+          "venue": "US Patent 9,117,089",
+          "authors": "MS Yoo, W Quan",
           "description": ""
         },
         {
@@ -1137,39 +1155,21 @@
           "description": ""
         },
         {
-          "title": "Facebook fan page evaluation system based on user opinion mining",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:sSrBHYA8nusC",
-          "citation": "TN Phan, M Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2015, 2015",
-          "cited_by": 7,
-          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
-          "authors": "TN Phan, M Yoo",
+          "title": "Information Evaluation Model for Social Network Users",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:r0BpntZqJG4C",
+          "citation": "DL Nguyen, TH Do, M Yoo - International Information Institute (Tokyo). Information 18 (2), 587, 2015, 2015",
+          "cited_by": 0,
+          "venue": "International Information Institute (Tokyo). Information 18 (2), 587",
+          "authors": "DL Nguyen, TH Do, M Yoo",
           "description": ""
         },
         {
-          "title": "Method and apparatus for controlling access in a social network service",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:qxL8FJ1GzNcC",
-          "citation": "MS Yoo, W Quan - US Patent 9,117,089, 2015, 2015",
-          "cited_by": 6,
-          "venue": "US Patent 9,117,089",
-          "authors": "MS Yoo, W Quan",
-          "description": ""
-        },
-        {
-          "title": "Tag search system using the keyword extraction and similarity evaluation",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:nb7KW1ujOQ8C",
-          "citation": "J Jung, M Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2015, 2015",
-          "cited_by": 6,
-          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
-          "authors": "J Jung, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Recent advances of ICT convergence on wsn applications",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:QIV2ME_5wuYC",
-          "citation": "M Yoo, F Wu, C Qiao - International Journal of Distributed Sensor Networks 11 (8), 247371, 2015, 2015",
-          "cited_by": 5,
-          "venue": "International Journal of Distributed Sensor Networks 11 (8), 247371",
-          "authors": "M Yoo, F Wu, C Qiao",
+          "title": "Potentialities and challenges of VLC based outdoor positioning",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:YOwf2qJgpHMC",
+          "citation": "TH Do, M Yoo - 2015 International Conference on Information Networking (ICOIN), 474-477, 2015, 2015",
+          "cited_by": 45,
+          "venue": "2015 International Conference on Information Networking (ICOIN), 474-477",
+          "authors": "TH Do, M Yoo",
           "description": ""
         },
         {
@@ -1182,12 +1182,21 @@
           "description": ""
         },
         {
-          "title": "Mobile terminal capable of localization, localization server and method for localizing the mobile terminal using the localization server",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:AXPGKjj_ei8C",
-          "citation": "M Yoo, J Hwang - US Patent 9,184,837, 2015, 2015",
-          "cited_by": 2,
-          "venue": "US Patent 9,184,837",
-          "authors": "M Yoo, J Hwang",
+          "title": "Facebook fan page evaluation system based on user opinion mining",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:sSrBHYA8nusC",
+          "citation": "TN Phan, M Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2015, 2015",
+          "cited_by": 7,
+          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
+          "authors": "TN Phan, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Tag search system using the keyword extraction and similarity evaluation",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:nb7KW1ujOQ8C",
+          "citation": "J Jung, M Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2015, 2015",
+          "cited_by": 6,
+          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
+          "authors": "J Jung, M Yoo",
           "description": ""
         },
         {
@@ -1198,57 +1207,12 @@
           "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
           "authors": "P Huynh, M Yoo",
           "description": ""
-        },
-        {
-          "title": "Information Evaluation Model for Social Network Users",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:r0BpntZqJG4C",
-          "citation": "DL Nguyen, TH Do, M Yoo - International Information Institute (Tokyo). Information 18 (2), 587, 2015, 2015",
-          "cited_by": 0,
-          "venue": "International Information Institute (Tokyo). Information 18 (2), 587",
-          "authors": "DL Nguyen, TH Do, M Yoo",
-          "description": ""
         }
       ]
     },
     {
       "year": 2014,
       "entries": [
-        {
-          "title": "TDOA-based indoor positioning using visible light",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:eQOLeE2rZwMC",
-          "citation": "TH Do, M Yoo - Photonic Network Communications 27 (2), 80-88, 2014, 2014",
-          "cited_by": 145,
-          "venue": "Photonic Network Communications 27 (2), 80-88",
-          "authors": "TH Do, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "The lexicon-based sentiment analysis for fan page ranking in Facebook",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:UxriW0iASnsC",
-          "citation": "PT Ngoc, M Yoo - The International Conference on Information Networking 2014 (ICOIN2014), 444-448, 2014, 2014",
-          "cited_by": 61,
-          "venue": "The International Conference on Information Networking 2014 (ICOIN2014), 444-448",
-          "authors": "PT Ngoc, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Optimization for link quality and power consumption of visible light communication system",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:JV2RwH3_ST0C",
-          "citation": "TH Do, M Yoo - Photonic Network Communications 27 (3), 99-105, 2014, 2014",
-          "cited_by": 17,
-          "venue": "Photonic Network Communications 27 (3), 99-105",
-          "authors": "TH Do, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Performance analysis and optimization of MAC frame size in IEEE 802.15. 7",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:0EnyYjriUFMC",
-          "citation": "J Hwang, TH Do, M Yoo - Wireless personal communications 78 (4), 2025-2035, 2014, 2014",
-          "cited_by": 7,
-          "venue": "Wireless personal communications 78 (4), 2025-2035",
-          "authors": "J Hwang, TH Do, M Yoo",
-          "description": ""
-        },
         {
           "title": "Performance analysis of packet loss on wireless network control systems",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:4TOpqqG69KYC",
@@ -1259,12 +1223,12 @@
           "description": ""
         },
         {
-          "title": "Performance Analysis of Packet Loss Impact on Scheduling in Wireless Real-Time Control System using Matlab/Simulink",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:SdhP9T11ey4C",
-          "citation": "NVA Quang, M Yoo - International Information Institute (Tokyo). Information 17 (4), 1495, 2014, 2014",
-          "cited_by": 1,
-          "venue": "International Information Institute (Tokyo). Information 17 (4), 1495",
-          "authors": "NVA Quang, M Yoo",
+          "title": "Performance analysis and optimization of MAC frame size in IEEE 802.15. 7",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:0EnyYjriUFMC",
+          "citation": "J Hwang, TH Do, M Yoo - Wireless personal communications 78 (4), 2025-2035, 2014, 2014",
+          "cited_by": 7,
+          "venue": "Wireless personal communications 78 (4), 2025-2035",
+          "authors": "J Hwang, TH Do, M Yoo",
           "description": ""
         },
         {
@@ -1283,6 +1247,42 @@
           "cited_by": 0,
           "venue": "International Information Institute (Tokyo). Information 17 (6), 2101",
           "authors": "W Quan, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Optimization for link quality and power consumption of visible light communication system",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:JV2RwH3_ST0C",
+          "citation": "TH Do, M Yoo - Photonic Network Communications 27 (3), 99-105, 2014, 2014",
+          "cited_by": 17,
+          "venue": "Photonic Network Communications 27 (3), 99-105",
+          "authors": "TH Do, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Performance Analysis of Packet Loss Impact on Scheduling in Wireless Real-Time Control System using Matlab/Simulink",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:SdhP9T11ey4C",
+          "citation": "NVA Quang, M Yoo - International Information Institute (Tokyo). Information 17 (4), 1495, 2014, 2014",
+          "cited_by": 1,
+          "venue": "International Information Institute (Tokyo). Information 17 (4), 1495",
+          "authors": "NVA Quang, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "TDOA-based indoor positioning using visible light",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:eQOLeE2rZwMC",
+          "citation": "TH Do, M Yoo - Photonic Network Communications 27 (2), 80-88, 2014, 2014",
+          "cited_by": 145,
+          "venue": "Photonic Network Communications 27 (2), 80-88",
+          "authors": "TH Do, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "The lexicon-based sentiment analysis for fan page ranking in Facebook",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:UxriW0iASnsC",
+          "citation": "PT Ngoc, M Yoo - The International Conference on Information Networking 2014 (ICOIN2014), 444-448, 2014, 2014",
+          "cited_by": 61,
+          "venue": "The International Conference on Information Networking 2014 (ICOIN2014), 444-448",
+          "authors": "PT Ngoc, M Yoo",
           "description": ""
         },
         {
@@ -1309,24 +1309,6 @@
       "year": 2013,
       "entries": [
         {
-          "title": "TDoA based indoor visible light positioning systems",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:eJXPG6dFmWUC",
-          "citation": "TH Do, J Hwang, M Yoo - 2013 Fifth international conference on ubiquitous and future networks (ICUFN …, 2013, 2013",
-          "cited_by": 90,
-          "venue": "2013 Fifth international conference on ubiquitous and future networks (ICUFN …",
-          "authors": "TH Do, J Hwang, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Analysis of the effects of LED direction on the performance of visible light communication system",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:VOx2b1Wkg3QC",
-          "citation": "TH Do, J Hwang, M Yoo - Photonic network communications 25 (1), 60-72, 2013, 2013",
-          "cited_by": 33,
-          "venue": "Photonic network communications 25 (1), 60-72",
-          "authors": "TH Do, J Hwang, M Yoo",
-          "description": ""
-        },
-        {
           "title": "VLC-TDOA using sinusoidal pilot signal",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:d1gkVwhDpl0C",
           "citation": "Y Kim, Y Shin, M Yoo - 2013 International Conference on IT Convergence and Security (ICITCS), 1-3, 2013, 2013",
@@ -1336,48 +1318,30 @@
           "description": ""
         },
         {
-          "title": "Performance analysis on MAC protocol based on beacon-enabled visible personal area networks",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:pqnbT2bcN3wC",
-          "citation": "J Hwang, T Do, M Yoo - 2013 Fifth International Conference on Ubiquitous and Future Networks (ICUFN …, 2013, 2013",
-          "cited_by": 18,
-          "venue": "2013 Fifth International Conference on Ubiquitous and Future Networks (ICUFN …",
-          "authors": "J Hwang, T Do, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Redundant transmission in wireless networked control system over IEEE 802.15. 4e",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:WbkHhVStYXYC",
-          "citation": "BX Yen, M Yoo - The International Conference on Information Networking 2013 (ICOIN), 628-631, 2013, 2013",
-          "cited_by": 17,
-          "venue": "The International Conference on Information Networking 2013 (ICOIN), 628-631",
-          "authors": "BX Yen, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Enhanced VLC-TDoA algorithm for indoor positioning without LED-ID",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:1sJd4Hv_s6UC",
-          "citation": "TH Do, J Hwang, M Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2013, 2013",
-          "cited_by": 5,
-          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
-          "authors": "TH Do, J Hwang, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Performance evaluation of wireless networked control system based on IEEE 802.15. 4e with redundancy",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:Tyk-4Ss8FVUC",
-          "citation": "BX Yen, W Lee, Y Kim, M Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2013, 2013",
-          "cited_by": 5,
-          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
-          "authors": "BX Yen, W Lee, Y Kim, M Yoo",
-          "description": ""
-        },
-        {
           "title": "Reliability analysis of real-time control systems in industrial wireless network",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:Mojj43d5GZwC",
           "citation": "W Lee, Y Kim, S Lee, M Yoo - 2013 International Conference on ICT Convergence (ICTC), 1097-1098, 2013, 2013",
           "cited_by": 1,
           "venue": "2013 International Conference on ICT Convergence (ICTC), 1097-1098",
           "authors": "W Lee, Y Kim, S Lee, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "TDoA based indoor visible light positioning systems",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:eJXPG6dFmWUC",
+          "citation": "TH Do, J Hwang, M Yoo - 2013 Fifth international conference on ubiquitous and future networks (ICUFN …, 2013, 2013",
+          "cited_by": 90,
+          "venue": "2013 Fifth international conference on ubiquitous and future networks (ICUFN …",
+          "authors": "TH Do, J Hwang, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Performance analysis on MAC protocol based on beacon-enabled visible personal area networks",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:pqnbT2bcN3wC",
+          "citation": "J Hwang, T Do, M Yoo - 2013 Fifth International Conference on Ubiquitous and Future Networks (ICUFN …, 2013, 2013",
+          "cited_by": 18,
+          "venue": "2013 Fifth International Conference on Ubiquitous and Future Networks (ICUFN …",
+          "authors": "J Hwang, T Do, M Yoo",
           "description": ""
         },
         {
@@ -1396,6 +1360,24 @@
           "cited_by": 0,
           "venue": "한국통신학회논문지 38 (6), 485-491",
           "authors": "전문길， 황준호， 유명식",
+          "description": ""
+        },
+        {
+          "title": "Analysis of the effects of LED direction on the performance of visible light communication system",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:VOx2b1Wkg3QC",
+          "citation": "TH Do, J Hwang, M Yoo - Photonic network communications 25 (1), 60-72, 2013, 2013",
+          "cited_by": 33,
+          "venue": "Photonic network communications 25 (1), 60-72",
+          "authors": "TH Do, J Hwang, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Redundant transmission in wireless networked control system over IEEE 802.15. 4e",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:WbkHhVStYXYC",
+          "citation": "BX Yen, M Yoo - The International Conference on Information Networking 2013 (ICOIN), 628-631, 2013, 2013",
+          "cited_by": 17,
+          "venue": "The International Conference on Information Networking 2013 (ICOIN), 628-631",
+          "authors": "BX Yen, M Yoo",
           "description": ""
         },
         {
@@ -1435,12 +1417,30 @@
           "description": ""
         },
         {
+          "title": "Enhanced VLC-TDoA algorithm for indoor positioning without LED-ID",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:1sJd4Hv_s6UC",
+          "citation": "TH Do, J Hwang, M Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2013, 2013",
+          "cited_by": 5,
+          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
+          "authors": "TH Do, J Hwang, M Yoo",
+          "description": ""
+        },
+        {
           "title": "A Simulation Study of MAC Protocol Based on Beacon Mode for Considering IEEE 802.15. 7 Star Topology Visible Personal Area Network System",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:a0OBvERweLwC",
           "citation": "J Hwang, M Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2013, 2013",
           "cited_by": 0,
           "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
           "authors": "J Hwang, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Performance evaluation of wireless networked control system based on IEEE 802.15. 4e with redundancy",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:Tyk-4Ss8FVUC",
+          "citation": "BX Yen, W Lee, Y Kim, M Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2013, 2013",
+          "cited_by": 5,
+          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
+          "authors": "BX Yen, W Lee, Y Kim, M Yoo",
           "description": ""
         }
       ]
@@ -1449,12 +1449,12 @@
       "year": 2012,
       "entries": [
         {
-          "title": "Modeling and analysis of the wireless channel formed by LED angle in visible light communication",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:M3ejUd6NZC8C",
-          "citation": "D Tronghop, J Hwang, S Jung, Y Shin, M Yoo - The International Conference on Information Network 2012, 354-357, 2012, 2012",
-          "cited_by": 47,
-          "venue": "The International Conference on Information Network 2012, 354-357",
-          "authors": "D Tronghop, J Hwang, S Jung, Y Shin, M Yoo",
+          "title": "A new framework for secure sharing data on cloud-based social networks",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:SP6oXDckpogC",
+          "citation": "NM Dien, J Hwang, M Yoo - 2012 International Conference on ICT Convergence (ICTC), 333-335, 2012, 2012",
+          "cited_by": 5,
+          "venue": "2012 International Conference on ICT Convergence (ICTC), 333-335",
+          "authors": "NM Dien, J Hwang, M Yoo",
           "description": ""
         },
         {
@@ -1467,39 +1467,21 @@
           "description": ""
         },
         {
-          "title": "The analysis on positioning error of recognition schemes of pilot signal in indoor TDoA positioning system using visible light communication",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:Tiz5es2fbqcC",
-          "citation": "J Hwang, M Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2012, 2012",
-          "cited_by": 8,
-          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
-          "authors": "J Hwang, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "A new framework for secure sharing data on cloud-based social networks",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:SP6oXDckpogC",
-          "citation": "NM Dien, J Hwang, M Yoo - 2012 International Conference on ICT Convergence (ICTC), 333-335, 2012, 2012",
-          "cited_by": 5,
-          "venue": "2012 International Conference on ICT Convergence (ICTC), 333-335",
-          "authors": "NM Dien, J Hwang, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "An enhanced MAC protocol based on FDD for reducing the delay in visible LAN systems",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:K3LRdlH-MEoC",
-          "citation": "J Hwang, M Yoo - Journal of the Institute of Electronics and Information Engineers 49 (10), 3-10, 2012, 2012",
-          "cited_by": 4,
-          "venue": "Journal of the Institute of Electronics and Information Engineers 49 (10), 3-10",
-          "authors": "J Hwang, M Yoo",
-          "description": ""
-        },
-        {
           "title": "A Methodology to Reduce the Effect of Variable Delay Using Online Gain Scheduling Algorithm in Industrial Control Systems",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:RGFaLdJalmkC",
           "citation": "BX Yen, T Do, D Ryu, J Hwang, M Yoo, C Oh - 한국통신학회 학술대회논문집, 243-244, 2012, 2012",
           "cited_by": 0,
           "venue": "한국통신학회 학술대회논문집, 243-244",
           "authors": "BX Yen, T Do, D Ryu, J Hwang, M Yoo, C Oh",
+          "description": ""
+        },
+        {
+          "title": "Modeling and analysis of the wireless channel formed by LED angle in visible light communication",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:M3ejUd6NZC8C",
+          "citation": "D Tronghop, J Hwang, S Jung, Y Shin, M Yoo - The International Conference on Information Network 2012, 354-357, 2012, 2012",
+          "cited_by": 47,
+          "venue": "The International Conference on Information Network 2012, 354-357",
+          "authors": "D Tronghop, J Hwang, S Jung, Y Shin, M Yoo",
           "description": ""
         },
         {
@@ -1519,12 +1501,39 @@
           "venue": "Journal of the Institute of Electronics and Information Engineers 49 (10), 11-17",
           "authors": "D Dotronghop, J Hwang, M Yoo",
           "description": ""
+        },
+        {
+          "title": "An enhanced MAC protocol based on FDD for reducing the delay in visible LAN systems",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:K3LRdlH-MEoC",
+          "citation": "J Hwang, M Yoo - Journal of the Institute of Electronics and Information Engineers 49 (10), 3-10, 2012, 2012",
+          "cited_by": 4,
+          "venue": "Journal of the Institute of Electronics and Information Engineers 49 (10), 3-10",
+          "authors": "J Hwang, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "The analysis on positioning error of recognition schemes of pilot signal in indoor TDoA positioning system using visible light communication",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:Tiz5es2fbqcC",
+          "citation": "J Hwang, M Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2012, 2012",
+          "cited_by": 8,
+          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
+          "authors": "J Hwang, M Yoo",
+          "description": ""
         }
       ]
     },
     {
       "year": 2011,
       "entries": [
+        {
+          "title": "Class-limited algorithm for supporting QoS and fairness in Ethernet passive optical network",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:JoZmwDi-zQgC",
+          "citation": "J Hwang, M Yoo - Photonic Network Communications 22 (3), 221-229, 2011, 2011",
+          "cited_by": 3,
+          "venue": "Photonic Network Communications 22 (3), 221-229",
+          "authors": "J Hwang, M Yoo",
+          "description": ""
+        },
         {
           "title": "Method for adaptive discontinuous reception based on extented paging indicator for improvement of power effective performance at mobile terminal on WCDMA",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:R3hNpaxXUhUC",
@@ -1544,21 +1553,12 @@
           "description": ""
         },
         {
-          "title": "Class-limited algorithm for supporting QoS and fairness in Ethernet passive optical network",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:JoZmwDi-zQgC",
-          "citation": "J Hwang, M Yoo - Photonic Network Communications 22 (3), 221-229, 2011, 2011",
-          "cited_by": 3,
-          "venue": "Photonic Network Communications 22 (3), 221-229",
-          "authors": "J Hwang, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "The Analysis of Effects of LED Panel Position and Lighting Angle on Communication Channel Quality in Indoor Visible Light Communication Systems",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:HDshCWvjkbEC",
-          "citation": "T Do, JH Hwang, MS Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2011, 2011",
-          "cited_by": 3,
-          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
-          "authors": "T Do, JH Hwang, MS Yoo",
+          "title": "A Routing Metric Based on Available Bandwidth Routing in Wireless Mesh Networks",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:N5tVd3kTz84C",
+          "citation": "J LEE, J HWANG, M YOO - 收藏 3, 2011, 2011",
+          "cited_by": 0,
+          "venue": "收藏 3",
+          "authors": "J LEE, J HWANG, M YOO",
           "description": ""
         },
         {
@@ -1571,12 +1571,12 @@
           "description": ""
         },
         {
-          "title": "A Routing Metric Based on Available Bandwidth Routing in Wireless Mesh Networks",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:N5tVd3kTz84C",
-          "citation": "J LEE, J HWANG, M YOO - 收藏 3, 2011, 2011",
-          "cited_by": 0,
-          "venue": "收藏 3",
-          "authors": "J LEE, J HWANG, M YOO",
+          "title": "The Analysis of Effects of LED Panel Position and Lighting Angle on Communication Channel Quality in Indoor Visible Light Communication Systems",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:HDshCWvjkbEC",
+          "citation": "T Do, JH Hwang, MS Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2011, 2011",
+          "cited_by": 3,
+          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
+          "authors": "T Do, JH Hwang, MS Yoo",
           "description": ""
         }
       ]
@@ -1591,24 +1591,6 @@
           "cited_by": 24,
           "venue": "2010 International Conference on Information and Communication Technology …",
           "authors": "BH Kim, HJ Ahn, JO Kim, M Yoo, KJ Cho, DS Choi",
-          "description": ""
-        },
-        {
-          "title": "Interference-free multipath routing protocol for M2M wireless network to enhance packet delay performance",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:5nxA0vEk-isC",
-          "citation": "HM Heo, JH Hwang, MS Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2010, 2010",
-          "cited_by": 7,
-          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
-          "authors": "HM Heo, JH Hwang, MS Yoo",
-          "description": ""
-        },
-        {
-          "title": "A weighted combining wireless location algorithm for mobile-WiMAX femto-cell environments",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:UeHWp8X0CEIC",
-          "citation": "S Kim, M Yoo, Y Shin - IEICE transactions on communications 93 (3), 749-752, 2010, 2010",
-          "cited_by": 2,
-          "venue": "IEICE transactions on communications 93 (3), 749-752",
-          "authors": "S Kim, M Yoo, Y Shin",
           "description": ""
         },
         {
@@ -1646,6 +1628,24 @@
           "venue": "Journal of the Institute of Electronics Engineers of Korea TC 47 (7), 51-58",
           "authors": "JS Lee, MS Yoo",
           "description": ""
+        },
+        {
+          "title": "Interference-free multipath routing protocol for M2M wireless network to enhance packet delay performance",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:5nxA0vEk-isC",
+          "citation": "HM Heo, JH Hwang, MS Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2010, 2010",
+          "cited_by": 7,
+          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
+          "authors": "HM Heo, JH Hwang, MS Yoo",
+          "description": ""
+        },
+        {
+          "title": "A weighted combining wireless location algorithm for mobile-WiMAX femto-cell environments",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:UeHWp8X0CEIC",
+          "citation": "S Kim, M Yoo, Y Shin - IEICE transactions on communications 93 (3), 749-752, 2010, 2010",
+          "cited_by": 2,
+          "venue": "IEICE transactions on communications 93 (3), 749-752",
+          "authors": "S Kim, M Yoo, Y Shin",
+          "description": ""
         }
       ]
     },
@@ -1659,6 +1659,15 @@
           "cited_by": 38,
           "venue": "Journal of Optical Communications and Networking 2 (1), 38-50",
           "authors": "J Choi, M Yoo, B Mukherjee",
+          "description": ""
+        },
+        {
+          "title": "Link Stability-Aware Ad Hoc Routing Protocol with Multiple Sampling Rates",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:OU6Ihb5iCvQC",
+          "citation": "M Yoo, J Lee, Y Kim, S Jung - Conference on Smart Spaces, 323-333, 2009, 2009",
+          "cited_by": 5,
+          "venue": "Conference on Smart Spaces, 323-333",
+          "authors": "M Yoo, J Lee, Y Kim, S Jung",
           "description": ""
         },
         {
@@ -1677,24 +1686,6 @@
           "cited_by": 17,
           "venue": "2009 IEEE 20th International Symposium on Personal, Indoor and Mobile Radio …",
           "authors": "S Kim, J Lee, M Yoo, Y Shin",
-          "description": ""
-        },
-        {
-          "title": "Link Stability-Aware Ad Hoc Routing Protocol with Multiple Sampling Rates",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:OU6Ihb5iCvQC",
-          "citation": "M Yoo, J Lee, Y Kim, S Jung - Conference on Smart Spaces, 323-333, 2009, 2009",
-          "cited_by": 5,
-          "venue": "Conference on Smart Spaces, 323-333",
-          "authors": "M Yoo, J Lee, Y Kim, S Jung",
-          "description": ""
-        },
-        {
-          "title": "A Stable Clustering Scheme Based on Node Mobility for Mobile Ad Hoc Networks",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:3fE2CSJIrl8C",
-          "citation": "HS Kim, JH Hwang, MS Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2009, 2009",
-          "cited_by": 1,
-          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
-          "authors": "HS Kim, JH Hwang, MS Yoo",
           "description": ""
         },
         {
@@ -1731,6 +1722,15 @@
           "cited_by": 0,
           "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
           "authors": "SH Lee, MS Yoo",
+          "description": ""
+        },
+        {
+          "title": "A Stable Clustering Scheme Based on Node Mobility for Mobile Ad Hoc Networks",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:3fE2CSJIrl8C",
+          "citation": "HS Kim, JH Hwang, MS Yoo - The Journal of Korean Institute of Communications and Information Sciences …, 2009, 2009",
+          "cited_by": 1,
+          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
+          "authors": "HS Kim, JH Hwang, MS Yoo",
           "description": ""
         }
       ]
@@ -1789,48 +1789,12 @@
       "year": 2007,
       "entries": [
         {
-          "title": "Adaptive discontinuous reception mechanism for power saving in UMTS",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:bFI3QPDXJZMC",
-          "citation": "S Yang, M Yoo, Y Shin - IEEE communications letters 11 (1), 40-42, 2007, 2007",
-          "cited_by": 21,
-          "venue": "IEEE communications letters 11 (1), 40-42",
-          "authors": "S Yang, M Yoo, Y Shin",
-          "description": ""
-        },
-        {
-          "title": "A cost-efficient WDM-PON architecture supporting dynamic wavelength and time slot allocation",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:kRWSkSYxWN8C",
-          "citation": "H Kim, J Hwang, M Yoo - The 9th International Conference on Advanced Communication Technology 3 …, 2007, 2007",
-          "cited_by": 17,
-          "venue": "The 9th International Conference on Advanced Communication Technology 3 …",
-          "authors": "H Kim, J Hwang, M Yoo",
-          "description": ""
-        },
-        {
-          "title": "Resource-aware rendezvous algorithm for cognitive radio networks",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:8AbLer7MMksC",
-          "citation": "PJ Jeong, M Yoo - The 9th International Conference on Advanced Communication Technology 3 …, 2007, 2007",
-          "cited_by": 17,
-          "venue": "The 9th International Conference on Advanced Communication Technology 3 …",
-          "authors": "PJ Jeong, M Yoo",
-          "description": ""
-        },
-        {
           "title": "An effective MIMO-OFDM transmission scheme for IEEE 802.22 WRAN systems",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:5Ul4iDaHHb8C",
           "citation": "H Kim, J Kim, S Yang, M Hong, M Yoo, W Lee, Y Shin - 2007 2nd International Conference on Cognitive Radio Oriented Wireless …, 2007, 2007",
           "cited_by": 11,
           "venue": "2007 2nd International Conference on Cognitive Radio Oriented Wireless …",
           "authors": "H Kim, J Kim, S Yang, M Hong, M Yoo, W Lee, Y Shin",
-          "description": ""
-        },
-        {
-          "title": "A scalable ad hoc routing protocol based on logical topology for ubiquitous community network",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:mvPsJ3kp5DgC",
-          "citation": "H Kim, M Yoo - The 9th International Conference on Advanced Communication Technology 2 …, 2007, 2007",
-          "cited_by": 9,
-          "venue": "The 9th International Conference on Advanced Communication Technology 2 …",
-          "authors": "H Kim, M Yoo",
           "description": ""
         },
         {
@@ -1858,6 +1822,42 @@
           "cited_by": 0,
           "venue": "International Conference on Research in Networking, 1221-1224",
           "authors": "M Yoo, J Hwang",
+          "description": ""
+        },
+        {
+          "title": "A cost-efficient WDM-PON architecture supporting dynamic wavelength and time slot allocation",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:kRWSkSYxWN8C",
+          "citation": "H Kim, J Hwang, M Yoo - The 9th International Conference on Advanced Communication Technology 3 …, 2007, 2007",
+          "cited_by": 17,
+          "venue": "The 9th International Conference on Advanced Communication Technology 3 …",
+          "authors": "H Kim, J Hwang, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "A scalable ad hoc routing protocol based on logical topology for ubiquitous community network",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:mvPsJ3kp5DgC",
+          "citation": "H Kim, M Yoo - The 9th International Conference on Advanced Communication Technology 2 …, 2007, 2007",
+          "cited_by": 9,
+          "venue": "The 9th International Conference on Advanced Communication Technology 2 …",
+          "authors": "H Kim, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Resource-aware rendezvous algorithm for cognitive radio networks",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:8AbLer7MMksC",
+          "citation": "PJ Jeong, M Yoo - The 9th International Conference on Advanced Communication Technology 3 …, 2007, 2007",
+          "cited_by": 17,
+          "venue": "The 9th International Conference on Advanced Communication Technology 3 …",
+          "authors": "PJ Jeong, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Adaptive discontinuous reception mechanism for power saving in UMTS",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=100&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:bFI3QPDXJZMC",
+          "citation": "S Yang, M Yoo, Y Shin - IEEE communications letters 11 (1), 40-42, 2007, 2007",
+          "cited_by": 21,
+          "venue": "IEEE communications letters 11 (1), 40-42",
+          "authors": "S Yang, M Yoo, Y Shin",
           "description": ""
         },
         {
@@ -1929,6 +1929,15 @@
       "year": 2006,
       "entries": [
         {
+          "title": "Congestion-aware burst control algorithm for OBS networks",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:olpn-zPbct0C",
+          "citation": "J Hwang, C Park, M Yoo - Optical Transmission, Switching, and Subsystems IV 6353, 630-638, 2006, 2006",
+          "cited_by": 0,
+          "venue": "Optical Transmission, Switching, and Subsystems IV 6353, 630-638",
+          "authors": "J Hwang, C Park, M Yoo",
+          "description": ""
+        },
+        {
           "title": "An adaptive discontinuous reception mechanism based on extended paging indicator for power saving in UMTS",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:eq2jaN3J8jMC",
           "citation": "S Yang, M Yoo, Y Shin - IEEE Vehicular Technology Conference, 1-5, 2006, 2006",
@@ -1947,39 +1956,21 @@
           "description": ""
         },
         {
-          "title": "Receiver-Based rate control with one-way trip time for multimedia applications",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:pyW8ca7W8N0C",
-          "citation": "M Yoo, MC Hong, Y Kim - International Conference on Information Networking, 641-649, 2006, 2006",
-          "cited_by": 1,
-          "venue": "International Conference on Information Networking, 641-649",
-          "authors": "M Yoo, MC Hong, Y Kim",
-          "description": ""
-        },
-        {
-          "title": "Routing Algorithm based on Link Stability for Ad Hoc Wireless Networks",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:dhFuZR0502QC",
-          "citation": "L Se-Young, Y Myung-Sik - The Journal of Korean Institute of Communications and Information Sciences …, 2006, 2006",
-          "cited_by": 1,
-          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
-          "authors": "L Se-Young, Y Myung-Sik",
-          "description": ""
-        },
-        {
-          "title": "Congestion-aware burst control algorithm for OBS networks",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:olpn-zPbct0C",
-          "citation": "J Hwang, C Park, M Yoo - Optical Transmission, Switching, and Subsystems IV 6353, 630-638, 2006, 2006",
-          "cited_by": 0,
-          "venue": "Optical Transmission, Switching, and Subsystems IV 6353, 630-638",
-          "authors": "J Hwang, C Park, M Yoo",
-          "description": ""
-        },
-        {
           "title": "Adaptive Limited Dynamic Bandwidth Allocation Algorithm for EPON",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:kNdYIx-mwKoC",
           "citation": "J Hwang, H Kim, M Yoo - COIN-NGNCON 2006-The Joint International Conference on Optical Internet and …, 2006, 2006",
           "cited_by": 0,
           "venue": "COIN-NGNCON 2006-The Joint International Conference on Optical Internet and …",
           "authors": "J Hwang, H Kim, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Receiver-Based rate control with one-way trip time for multimedia applications",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:pyW8ca7W8N0C",
+          "citation": "M Yoo, MC Hong, Y Kim - International Conference on Information Networking, 641-649, 2006, 2006",
+          "cited_by": 1,
+          "venue": "International Conference on Information Networking, 641-649",
+          "authors": "M Yoo, MC Hong, Y Kim",
           "description": ""
         },
         {
@@ -2019,6 +2010,15 @@
           "description": ""
         },
         {
+          "title": "Routing Algorithm based on Link Stability for Ad Hoc Wireless Networks",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:dhFuZR0502QC",
+          "citation": "L Se-Young, Y Myung-Sik - The Journal of Korean Institute of Communications and Information Sciences …, 2006, 2006",
+          "cited_by": 1,
+          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
+          "authors": "L Se-Young, Y Myung-Sik",
+          "description": ""
+        },
+        {
           "title": "A QoS-aware Scheduling Algorithm for Multiuser Diversity MIMO-OFDM System",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:9yKSN-GCB0IC",
           "citation": "Y Myung-Sik - The Journal of Korean Institute of Communications and Information Sciences …, 2006, 2006",
@@ -2032,15 +2032,6 @@
     {
       "year": 2005,
       "entries": [
-        {
-          "title": "An Efficient Routing Protocol for the Hybrid Wireless Networks",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:hFOr9nPyWt4C",
-          "citation": "S Lim, M Yoo - 情報処理学会研究報告= IPSJ SIG technical reports 2005 (60), 149-154, 2005, 2005",
-          "cited_by": 1,
-          "venue": "情報処理学会研究報告= IPSJ SIG technical reports 2005 (60), 149-154",
-          "authors": "S Lim, M Yoo",
-          "description": ""
-        },
         {
           "title": "Class Gated Protocol for supporting QoS in Ethernet PON",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:EUQCXRtRnyEC",
@@ -2078,6 +2069,15 @@
           "description": ""
         },
         {
+          "title": "An Efficient Routing Protocol for the Hybrid Wireless Networks",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:hFOr9nPyWt4C",
+          "citation": "S Lim, M Yoo - 情報処理学会研究報告= IPSJ SIG technical reports 2005 (60), 149-154, 2005, 2005",
+          "cited_by": 1,
+          "venue": "情報処理学会研究報告= IPSJ SIG technical reports 2005 (60), 149-154",
+          "authors": "S Lim, M Yoo",
+          "description": ""
+        },
+        {
           "title": "Performance Analysis on Power Saving Mechanisms in IEEE 802.16 e Systems by Considering Downlink Traffic Conditions",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:ULOm3_A8WrAC",
           "citation": "SC Yang, SW Han, MS Yoo, YA Shin - Proceedings of the IEEK Conference, 311-316, 2005, 2005",
@@ -2110,15 +2110,6 @@
           "description": ""
         },
         {
-          "title": "A Variable Transmission Window MAC protocol for QoS Support in EPON System.",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:P5F9QuxV20EC",
-          "citation": "Y Myungsik - The Journal of Korean Institute of Communications and Information Sciences …, 2004, 2004",
-          "cited_by": 1,
-          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
-          "authors": "Y Myungsik",
-          "description": ""
-        },
-        {
           "title": "ERAP: Early Rate Adaptation Protocol over DiffServ for Multimedia Streaming Data",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:tuHXwOkdijsC",
           "citation": "Y Myungsik - Proceedings of the Korean Institute of Communication Sciences Conference …, 2004, 2004",
@@ -2132,6 +2123,15 @@
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:_B80troHkn4C",
           "citation": "Y Myungsik - The Journal of Korean Institute of Communications and Information Sciences …, 2004, 2004",
           "cited_by": 0,
+          "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
+          "authors": "Y Myungsik",
+          "description": ""
+        },
+        {
+          "title": "A Variable Transmission Window MAC protocol for QoS Support in EPON System.",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:P5F9QuxV20EC",
+          "citation": "Y Myungsik - The Journal of Korean Institute of Communications and Information Sciences …, 2004, 2004",
+          "cited_by": 1,
           "venue": "The Journal of Korean Institute of Communications and Information Sciences …",
           "authors": "Y Myungsik",
           "description": ""
@@ -2201,15 +2201,6 @@
       "year": 2002,
       "entries": [
         {
-          "title": "Survivability in the optical internet using the optical burst switch",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:abG-DnoFyZgC",
-          "citation": "S Oh, Y Kim, M Yoo, HH Hong - ETRI journal 24 (2), 117-130, 2002, 2002",
-          "cited_by": 34,
-          "venue": "ETRI journal 24 (2), 117-130",
-          "authors": "S Oh, Y Kim, M Yoo, HH Hong",
-          "description": ""
-        },
-        {
           "title": "Comparative study on burst assembly schemes for optical burst-switched networks",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:_Qo2XoVZTnwC",
           "citation": "DH Park, M Yoo - Optical Networking II 4910, 266-274, 2002, 2002",
@@ -2226,21 +2217,21 @@
           "venue": "Proceedings, COIN-PS",
           "authors": "S Oh, Y Kim, M Yoo",
           "description": ""
+        },
+        {
+          "title": "Survivability in the optical internet using the optical burst switch",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:abG-DnoFyZgC",
+          "citation": "S Oh, Y Kim, M Yoo, HH Hong - ETRI journal 24 (2), 117-130, 2002, 2002",
+          "cited_by": 34,
+          "venue": "ETRI journal 24 (2), 117-130",
+          "authors": "S Oh, Y Kim, M Yoo, HH Hong",
+          "description": ""
         }
       ]
     },
     {
       "year": 2001,
       "entries": [
-        {
-          "title": "Optical burst switching for service differentiation in the next-generation optical internet",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:yD5IFk8b50cC",
-          "citation": "M Yoo, C Qiao, S Dixit - IEEE Communications Magazine 39 (2), 98-104, 2001, 2001",
-          "cited_by": 381,
-          "venue": "IEEE Communications Magazine 39 (2), 98-104",
-          "authors": "M Yoo, C Qiao, S Dixit",
-          "description": ""
-        },
         {
           "title": "On an IP-centric optical control plane",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:TQgYirikUcIC",
@@ -2251,21 +2242,30 @@
           "description": ""
         },
         {
-          "title": "On design and architecture of an IP over WDM optical network control plane",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:WF5omc3nYNoC",
-          "citation": "C Xin, TS Wang, Y Ye, M Yoo, S Dixit, C Qiao - International IFIP Conference on Optical Network Design and Modeling, 297-312, 2001, 2001",
-          "cited_by": 5,
-          "venue": "International IFIP Conference on Optical Network Design and Modeling, 297-312",
-          "authors": "C Xin, TS Wang, Y Ye, M Yoo, S Dixit, C Qiao",
-          "description": ""
-        },
-        {
           "title": "on an IP-centric optical Control Plane",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:4JMBOYKVnBMC",
           "citation": "C Qiao, M Yoo - IEEE Communications Magazine, 89, 2001, 2001",
           "cited_by": 0,
           "venue": "IEEE Communications Magazine, 89",
           "authors": "C Qiao, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Optical burst switching for service differentiation in the next-generation optical internet",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:yD5IFk8b50cC",
+          "citation": "M Yoo, C Qiao, S Dixit - IEEE Communications Magazine 39 (2), 98-104, 2001, 2001",
+          "cited_by": 381,
+          "venue": "IEEE Communications Magazine 39 (2), 98-104",
+          "authors": "M Yoo, C Qiao, S Dixit",
+          "description": ""
+        },
+        {
+          "title": "On design and architecture of an IP over WDM optical network control plane",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:WF5omc3nYNoC",
+          "citation": "C Xin, TS Wang, Y Ye, M Yoo, S Dixit, C Qiao - International IFIP Conference on Optical Network Design and Modeling, 297-312, 2001, 2001",
+          "cited_by": 5,
+          "venue": "International IFIP Conference on Optical Network Design and Modeling, 297-312",
+          "authors": "C Xin, TS Wang, Y Ye, M Yoo, S Dixit, C Qiao",
           "description": ""
         },
         {
@@ -2292,15 +2292,6 @@
           "description": ""
         },
         {
-          "title": "Choices, features and issues in optical burst switching",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:hqOjcs7Dif8C",
-          "citation": "C Qiao, M Yoo - Optical Networks Magazine 1 (2), 36-44, 2000, 2000",
-          "cited_by": 411,
-          "venue": "Optical Networks Magazine 1 (2), 36-44",
-          "authors": "C Qiao, M Yoo",
-          "description": ""
-        },
-        {
           "title": "Comparative study of contention resolution policies in optical burst-switched WDM networks",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:hMod-77fHWUC",
           "citation": "M Yoo, C Qiao, S Dixit - Terabit Optical Networking: Architecture, Control, and Management Issues …, 2000, 2000",
@@ -2319,12 +2310,12 @@
           "description": ""
         },
         {
-          "title": "Polymorphic Control for Cost‐Effective Design of Optical Networks",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:gsN89kCJA0AC",
-          "citation": "Q Chunming, M Yousong, Y Myungsik, Z Xijun - European transactions on Telecommunications 11 (1), 17-26, 2000, 2000",
-          "cited_by": 35,
-          "venue": "European transactions on Telecommunications 11 (1), 17-26",
-          "authors": "Q Chunming, M Yousong, Y Myungsik, Z Xijun",
+          "title": "Choices, features and issues in optical burst switching",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:hqOjcs7Dif8C",
+          "citation": "C Qiao, M Yoo - Optical Networks Magazine 1 (2), 36-44, 2000, 2000",
+          "cited_by": 411,
+          "venue": "Optical Networks Magazine 1 (2), 36-44",
+          "authors": "C Qiao, M Yoo",
           "description": ""
         },
         {
@@ -2346,6 +2337,15 @@
           "description": ""
         },
         {
+          "title": "Polymorphic Control for Cost‐Effective Design of Optical Networks",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:gsN89kCJA0AC",
+          "citation": "Q Chunming, M Yousong, Y Myungsik, Z Xijun - European transactions on Telecommunications 11 (1), 17-26, 2000, 2000",
+          "cited_by": 35,
+          "venue": "European transactions on Telecommunications 11 (1), 17-26",
+          "authors": "Q Chunming, M Yousong, Y Myungsik, Z Xijun",
+          "description": ""
+        },
+        {
           "title": "Optical burst switching for the next generation Optical Internet",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:uJ-U7cs_P_0C",
           "citation": "M Yoo - State University of New York at Buffalo, 2000, 2000",
@@ -2359,15 +2359,6 @@
     {
       "year": 1999,
       "entries": [
-        {
-          "title": "Optical burst switching (OBS) – a new paradigm for an Optical Internet",
-          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:Y5dfb0dijaUC",
-          "citation": "C Qiao, M Yoo - Journal of high speed networks 8 (1), 69-84, 1999, 1999",
-          "cited_by": 2937,
-          "venue": "Journal of high speed networks 8 (1), 69-84",
-          "authors": "C Qiao, M Yoo",
-          "description": ""
-        },
         {
           "title": "Supporting multiple classes of services in IP over WDM networks",
           "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:zA6iFVUQeVQC",
@@ -2384,6 +2375,15 @@
           "cited_by": 77,
           "venue": "Optical Fiber Communication Conference, ThM6",
           "authors": "M Yoo, C Qiao",
+          "description": ""
+        },
+        {
+          "title": "Optical burst switching (OBS) – a new paradigm for an Optical Internet",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:Y5dfb0dijaUC",
+          "citation": "C Qiao, M Yoo - Journal of high speed networks 8 (1), 69-84, 1999, 1999",
+          "cited_by": 2937,
+          "venue": "Journal of high speed networks 8 (1), 69-84",
+          "authors": "C Qiao, M Yoo",
           "description": ""
         }
       ]
@@ -2412,6 +2412,101 @@
           "cited_by": 715,
           "venue": "1997 Digest of the IEEE/LEOS Summer Topical Meeting: Vertical-Cavity Lasers …",
           "authors": "M Yoo, C Qiao",
+          "description": ""
+        }
+      ]
+    },
+    {
+      "year": 0,
+      "entries": [
+        {
+          "title": "Tacker 기반 NFV 시스템의 워크플로우 정책 기반 VNF 모니터링 모델",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:_axFR9aDTf0C",
+          "citation": "TH Nguyen, M Yoo",
+          "cited_by": 0,
+          "venue": "",
+          "authors": "TH Nguyen, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "소셜 네트워크를 위한 확산 확률과 노드 연결성 기반의정보 확산 최대화 알고리즘",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:PoWvk5oyLR8C",
+          "citation": "ND Linh, W Quan, J Hwang, M Yoo",
+          "cited_by": 0,
+          "venue": "",
+          "authors": "ND Linh, W Quan, J Hwang, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Optimized Placement of Symmetrical Service Function",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:b1wdh0AR-JQC",
+          "citation": "NM Dang-Quang, M Yoo",
+          "cited_by": 0,
+          "venue": "",
+          "authors": "NM Dang-Quang, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Department of Electrical and Computer Engineering State University of New York at Bu alo Bu alo, New York 14260 fmyoo, mjeong, qiaog@ eng. bu alo. edu",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:j8SEvjWlNXcC",
+          "citation": "M Yoo, M Jeong, C Qiao",
+          "cited_by": 0,
+          "venue": "",
+          "authors": "M Yoo, M Jeong, C Qiao",
+          "description": ""
+        },
+        {
+          "title": "A High Speed Protocol for Bursty Tra c in Optical Networks",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:fEOibwPWpKIC",
+          "citation": "M Yoo, M Jeong, C Qiao",
+          "cited_by": 0,
+          "venue": "",
+          "authors": "M Yoo, M Jeong, C Qiao",
+          "description": ""
+        },
+        {
+          "title": "NFV 에서 동적 Service Function Chain 업데이트를 위한 메커니즘",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:NJ774b8OgUMC",
+          "citation": "T Nguyen, M Yoo",
+          "cited_by": 0,
+          "venue": "",
+          "authors": "T Nguyen, M Yoo",
+          "description": ""
+        },
+        {
+          "title": "균형 능력 평가를 위한 족부 압력 중심 및 압력 분포 실시간 시각화 애플리케이션",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:BrmTIyaxlBUC",
+          "citation": "M Kim, EY Lee, MS Yoo, K Paek, DH Kim",
+          "cited_by": 0,
+          "venue": "",
+          "authors": "M Kim, EY Lee, MS Yoo, K Paek, DH Kim",
+          "description": ""
+        },
+        {
+          "title": "The Effect of Limited Fiber Delay Lines on QoS Performance of Optical Burst",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:vRqMK49ujn8C",
+          "citation": "M Yoo",
+          "cited_by": 0,
+          "venue": "",
+          "authors": "M Yoo",
+          "description": ""
+        },
+        {
+          "title": "Polymorphic Control for Cost-E ective Design of Optical Networks",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:4OULZ7Gr8RgC",
+          "citation": "C Qiao, Y Mei, M Yoo, X Zhang",
+          "cited_by": 0,
+          "venue": "",
+          "authors": "C Qiao, Y Mei, M Yoo, X Zhang",
+          "description": ""
+        },
+        {
+          "title": "Department of Electrical and Computer Engineering State University of New York at Buffalo Buffalo, New York 14260",
+          "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=TARMZOsAAAAJ&cstart=200&pagesize=100&sortby=pubdate&citation_for_view=TARMZOsAAAAJ:iH-uZ7U-co4C",
+          "citation": "M Yoo, M Jeong, C Qiao",
+          "cited_by": 0,
+          "venue": "",
+          "authors": "M Yoo, M Jeong, C Qiao",
           "description": ""
         }
       ]


### PR DESCRIPTION
## Summary
- 261 publications (was 251 — entries with no year no longer dropped)
- Entries now in Scholar's publication date order instead of citation count
- Locally synced due to Scholar 403-blocking GitHub Actions IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)