### PR TITLE
fix: graceful Scholar fallback — still update abstracts

### DIFF
--- a/scripts/fetch_publications.js
+++ b/scripts/fetch_publications.js
@@ -137,11 +137,26 @@ async function main() {
     }
   } catch (err) {
     if (allPubs.length === 0) {
-      console.error('Failed to fetch any publications:', err.message);
-      console.error('Keeping existing publications.json untouched.');
-      process.exit(1);
+      console.warn('Scholar blocked us:', err.message);
+      console.log('Falling back to existing publications — will still update abstracts.');
+      try {
+        const existing = JSON.parse(fs.readFileSync(OUTPUT, 'utf8'));
+        allPubs = existing.publications.flatMap(y =>
+          (y.entries || []).map(e => ({ ...e, year: y.year }))
+        );
+        stats = {
+          total_citations: existing.total_citations,
+          h_index: existing.h_index,
+          i10_index: existing.i10_index,
+        };
+        console.log(`  Loaded ${allPubs.length} existing publications.`);
+      } catch {
+        console.error('No existing data to fall back on. Aborting.');
+        process.exit(1);
+      }
+    } else {
+      console.warn(`Warning: stopped early after ${allPubs.length} publications: ${err.message}`);
     }
-    console.warn(`Warning: stopped early after ${allPubs.length} publications: ${err.message}`);
   }
 
   // Get author stats from first page


### PR DESCRIPTION
## Summary
- When Scholar returns 403/429, fall back to existing publications.json instead of crashing
- Still re-fetches all abstracts from OpenAlex on fallback
- Weekly Sunday 3AM scrape handles new papers (rarely blocked at that frequency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)