### PR TITLE
fix: center year nav + smaller Other label

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -911,7 +911,7 @@ p {
   z-index: 50;
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
   gap: 1px;
   padding: 0.4rem 0.25rem;
   background: var(--bg-color);
@@ -925,6 +925,7 @@ p {
 .year-nav::-webkit-scrollbar { display: none; }
 .year-nav-item {
   display: block;
+  text-align: center;
   padding: 0.15rem 0.5rem;
   border-radius: 6px;
   font-size: 0.68rem;

--- a/publications.md
+++ b/publications.md
@@ -27,13 +27,13 @@ permalink: /publications/
 
 <nav class="year-nav" id="year-nav" aria-label="Jump to year">
   {% for year_group in site.data.publications.publications %}
-  <a href="#year-{{ year_group.year }}" class="year-nav-item" data-year="{{ year_group.year }}">{% if year_group.year == 0 %}Other{% else %}{{ year_group.year }}{% endif %}</a>
+  <a href="#year-{{ year_group.year }}" class="year-nav-item" data-year="{{ year_group.year }}">{% if year_group.year == 0 %}<span style="font-size:0.85em">Other</span>{% else %}{{ year_group.year }}{% endif %}</a>
   {% endfor %}
 </nav>
 
 {% for year_group in site.data.publications.publications %}
 <section class="publication-section" id="year-{{ year_group.year }}">
-  <h2 class="publication-year">{% if year_group.year == 0 %}Other{% else %}{{ year_group.year }}{% endif %}</h2>
+  <h2 class="publication-year">{% if year_group.year == 0 %}<span style="font-size:0.85em">Other</span>{% else %}{{ year_group.year }}{% endif %}</h2>
   <ul class="publication-list">
     {% for pub in year_group.entries %}
     <li class="publication-item" data-description="{{ pub.description | escape }}" data-authors="{{ pub.authors | escape }}" data-venue="{{ pub.venue | escape }}" data-cited="{{ pub.cited_by }}" data-year="{{ year_group.year }}">


### PR DESCRIPTION
## Summary
- Center-align year nav items
- Smaller font for "Other" label to match year width

🤖 Generated with [Claude Code](https://claude.com/claude-code)