### PR TITLE
fix: enable font weight animation on mobile

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -415,7 +415,7 @@ document.querySelectorAll('.stat-number').forEach((el) => {
 // ============================================================
 // 9. SCROLL-BASED FONT WEIGHT ON HEADINGS (variable font)
 // ============================================================
-if (!isMobile) {
+{
   const stretchHeadings = gsap.utils.toArray('.info-section h2, .transition-section h2');
   stretchHeadings.forEach((el) => {
     el.style.fontWeight = '400';


### PR DESCRIPTION
## Summary
- Unlock scroll-based font weight animation on mobile (was desktop-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)